### PR TITLE
Revert "cockpit.pyw sets cwd to its parent folder to avoid path errors."

### DIFF
--- a/cockpit.pyw
+++ b/cockpit.pyw
@@ -4,8 +4,6 @@
 # the GUI.
 
 import os
-os.chdir(os.path.dirname(os.path.abspath(__file__)))
-
 import threading
 import traceback
 import wx


### PR DESCRIPTION
Reverts MicronOxford/cockpit#32
