### PR TITLE
stop moves of direction 0

### DIFF
--- a/interfaces/stageMover.py
+++ b/interfaces/stageMover.py
@@ -162,7 +162,8 @@ def step(direction):
     for axis, sign in enumerate(direction):
         if (axis in mover.axisToHandlers and
                 mover.curHandlerIndex < len(mover.axisToHandlers[axis])):
-#IMD 20150414 don't need to move is sign=0, this prevent aerotech unlocking stage on every keyboard move
+            #IMD 20150414 don't need to move if sign==0.
+            # Prevents aerotech axis unlocking stage on every keyboard move.
             if (sign !=0):
                 mover.axisToHandlers[axis][mover.curHandlerIndex].moveStep(sign)
 


### PR DESCRIPTION
The keyboard move command moves all stage axis, most of them with direction "0" thi scauses the areotech drive to unlock and relock the stage at every keyboard move (but not mosaic or mouse click moves). This patch simply bypasses all moves of size zero, seems like a sensible efficiency saving as well, 
