### PR TITLE
Removed a wx.EXPAND so that short rows are short.

### DIFF
--- a/gui/mainWindow.py
+++ b/gui/mainWindow.py
@@ -130,7 +130,7 @@ class MainWindow(wx.Frame):
                     rowSizer.Add((1, -1), 1, wx.EXPAND)
                 rowSizer.Add(item)
 
-        topSizer.Add(rowSizer, 1, wx.EXPAND)
+        topSizer.Add(rowSizer, 1)
 
         topPanel.SetSizerAndFit(topSizer)
         mainSizer.Add(topPanel)


### PR DESCRIPTION
Otherwise, the short rows had a huge space between the last control and others.
