### PR TITLE
added raspberryPi digital IO device file.

### DIFF
--- a/devices/pi-DIO.py
+++ b/devices/pi-DIO.py
@@ -9,7 +9,7 @@ import wx
 
 from config import config
 CLASS_NAME = 'RaspberryPi'
-CONFIG_NAME = 'RPi'
+CONFIG_NAME = 'rpi'
 
 
 


### PR DESCRIPTION
This creates the pi-DIO device which does async digital IO (flip mirrors in our case) on a raspberry Pi. Should be safe as it is disabled unless there is a config section present. 

Remote code is in  https://github.com/iandobbie/pi-DIO so far works fine with one channel, needs config file and layout work...
