### PR TITLE
Added gui/device with common definitions for device controls.

### DIFF
--- a/gui/device.py
+++ b/gui/device.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-"""gui.display
+"""gui.device
 
 Copyright 2014-2015 Mick Phillips (mick.phillips at gmail dot com)
 
@@ -21,8 +21,8 @@ Class definitions for labels and value displays with default formatting.
 
 import wx
 
-## @package gui.label
-# This module contains the Label class.
+## @package gui.device
+# Defines classes for common controls used by cockpit devices.
 
 ## Default size
 DEFAULT_SIZE = (120, 24)


### PR DESCRIPTION
It would be great to get all the wx-specific stuff out of the device files, but I haven't figured out the best way to do that, yet.  For now, we can use these classes to reduce the code in the device files. This also means that the device files don't need to be concerned about formatting wx controls to keep a consistent appearance.
