### PR TITLE
added extra trigger for slm at start of exp, del at end

### DIFF
--- a/experiment/structuredIllumination.py
+++ b/experiment/structuredIllumination.py
@@ -101,6 +101,10 @@ class SIExperiment(experiment.Experiment):
             curTime += decimal.Decimal('1e-6')
         table.addAction(curTime, self.zPositioner, 0)
         curTime += decimal.Decimal('1e-6')
+		
+        if self.slmHandler is not None:
+            # Add a first trigger of the SLM to get first new image.
+            table.addAction(curTime, self.slmHandler, 0)
         
         for angle, phase, z in self.genSIPositions():
             delayBeforeImaging = 0
@@ -191,9 +195,7 @@ class SIExperiment(experiment.Experiment):
             table.addAction(curTime + motionTime, self.phaseHandler, 0)
             finalWaitTime = max(finalWaitTime, motionTime + stabilizationTime)
         
-        if self.slmHandler is not None:
-            # Add a last trigger of the SLM to cycle back to the start.
-            table.addAction(curTime, self.slmHandler, 0)
+ 
 
         return table
 


### PR DESCRIPTION
The login is wrong in the slm trigger sequence. We need an extra trigger at the start not the end. We need to load the first new image not recycle at the end of the experiment. This fixes the issue but only in the z,phase,angle collection order. All the other options are broken in some way. 
