### PR TITLE
move saftey limits on objective change

### DIFF
--- a/gui/mosaic/window.py
+++ b/gui/mosaic/window.py
@@ -364,7 +364,11 @@ class MosaicWindow(wx.Frame):
         for safeties, color, stipple in [(softSafeties, (0, 1, 0), 0x5555),
                 (hardSafeties, (0, 0, 1), 0xAAAA)]:
             x1, x2 = safeties[0]
+            x1 -=  self.offset[0]
+            x2 -=  self.offset[0]
             y1, y2 = safeties[1]
+            y1 -=  self.offset[1]
+            y2 -=  self.offset[1]
             glLineStipple(3, stipple)
             glColor3f(*color)
             glBegin(GL_LINE_LOOP)


### PR DESCRIPTION
Shifts the limits on objective change in mosaic window so that the objective can't suddenly move outside the limits due to image position shift on objective change
