### PR TITLE
Minor mosaic fixes

### DIFF
--- a/gui/mosaic/window.py
+++ b/gui/mosaic/window.py
@@ -326,8 +326,8 @@ class MosaicWindow(wx.Frame):
         for site in interfaces.stageMover.getAllSites():
             # Draw a crude circle.
             x, y = site.position[:2]
-            x = -x - self.offset[0]
-            y = y +self.offset[1]
+            x = -x + self.offset[0]
+            y = y -self.offset[1]
             # Set line width based on zoom factor.
             lineWidth = max(1, self.canvas.scale * 1.5)
             glLineWidth(lineWidth)


### PR DESCRIPTION
Couple of minor mosaic fixes. 

1) using the defaultFaceSize you defined
2) flipping the offsets on the site drawing as they were the wrong way round and jumped off the image when an objective with offset was selected.
