### PR TITLE
Fixes callbacks not printing.

### DIFF
--- a/gui/loggingWindow.py
+++ b/gui/loggingWindow.py
@@ -43,7 +43,8 @@ class LoggingWindow(wx.Frame):
 
     ## Send text to one of our output boxes, and also log that text.
     def write(self, target, *args):
-        wx.CallAfter(target.AppendText, *args)
+        #wx.CallAfter(target.AppendText, *args)
+        target.AppendText(*args)
         self.textCache += ' '.join(map(str, args))
         if '\n' in self.textCache:
             # Ended a line; send the text to the logs, minus any trailing


### PR DESCRIPTION
print, sys.{stdout, stderr}.write, and tracebacks on unhanded exceptions were not being printed to the logging panel.

This appears to be because wx.CallAfter promises to call the function to write to the text box after the current callback has finished, but it may not return quickly, as all the experiment setup logic is done in this callback.

This is also to workaround an issue I'm having whereby closed windows do not get fully cleaned up (OSX 10.10), and so errors are never printed.

Presumably this behaviour is desirable over just writing it directly for thread-safety reasons?
