### PR TITLE
Stage Positioner soft limits may exceed hard limits.

### DIFF
--- a/gui/loggingWindow.py
+++ b/gui/loggingWindow.py
@@ -43,8 +43,7 @@ class LoggingWindow(wx.Frame):
 
     ## Send text to one of our output boxes, and also log that text.
     def write(self, target, *args):
-        #wx.CallAfter(target.AppendText, *args)
-        target.AppendText(*args)
+        wx.CallAfter(target.AppendText, *args)
         self.textCache += ' '.join(map(str, args))
         if '\n' in self.textCache:
             # Ended a line; send the text to the logs, minus any trailing


### PR DESCRIPTION
The implicit assumption that the soft limits are smaller than the hard limits was never checked if you set the soft limits in **init** rather than in SetSoftLimit().

Fix this by raising RuntimeError.
