### PR TITLE
Removed toggleButton's right-click binding.

### DIFF
--- a/gui/toggleButton.py
+++ b/gui/toggleButton.py
@@ -53,7 +53,7 @@ class ToggleButton(wx.StaticText):
         # Realign the label using our custom version of the function
         self.SetLabel(self.GetLabel())
         self.Bind(wx.EVT_LEFT_DOWN, lambda event: self.toggle())
-        self.Bind(wx.EVT_RIGHT_DOWN, lambda event: self.toggle())
+        #self.Bind(wx.EVT_RIGHT_DOWN, lambda event: self.toggle())
 
 
     ## Override of normal StaticText SetLabel, to try to vertically


### PR DESCRIPTION
ToggleButton is used in many places as a control button, relying on some function which is typically bound to the left mouse button event, but not the right. Click with the LMB, and it works as expected; click with the RMB, and the button shows a change of state, although nothing else happened. I've removed the default RMB binding to prevent this confusing behaviour.
