### PR TITLE
SLM: more pretriggers to overcome hardware weirdness.

### DIFF
--- a/devices/boulderSLM.py
+++ b/devices/boulderSLM.py
@@ -150,16 +150,16 @@ class BoulderSLMDevice(device.Device):
         # Store the parameters used to generate the sequence.
         self.lastParms = sequence
         self.connection.run()
-        # Fire a couple of triggers to ensure that the sequence is loaded.
+        # Fire several triggers to ensure that the sequence is loaded.
         triggerNow = self.getTriggerHandler().callbacks.get('triggerNow')
-        triggerNow()
-        time.sleep(0.002)
-        triggerNow()
+        for i in range(12):
+            triggerNow()
+            time.sleep(0.01)
         # Ensure that we're at position 0.
         self.position = self.getCurrentPosition()
         while self.position != 0:
             triggerNow()
-            time.sleep(0.002)
+            time.sleep(0.01)
             self.position = self.getCurrentPosition()
 
 


### PR DESCRIPTION
The SLM was starting experiments on the right frame most of the time, but now and again would start some arbitrary number of frames off. Experiments with writing images of numbers to the SLM show that, after loading a new sequence, it typically takes two triggers for the image to match the sequence index reported by the hardware. It seems that sometimes it can take more than two triggers.
I've increased the number of pretriggers considerably, and increased the delay between triggers or between trigger and position read. So far, this seems to work.
