### PR TITLE
Fix issue from latest 1.10 numpy casting

### DIFF
--- a/gui/imageViewer/viewCanvas.py
+++ b/gui/imageViewer/viewCanvas.py
@@ -525,9 +525,9 @@ class ViewCanvas(wx.glcanvas.GLCanvas):
         coords[0] = self.GetClientSize()[1] - coords[0] - HISTOGRAM_HEIGHT
         # Apply zoom
         shape = numpy.array(self.imageShape)
-        coords -= shape / 2.0
+        coords = coords - ( shape / 2.0)
         coords /= self.zoom
-        coords += shape / 2.0
+        coords = coords + (shape / 2.0)
         # Apply pan
         coords -= [self.panY, self.panX]
         if numpy.all(coords < shape) and numpy.all(coords >= 0):


### PR DESCRIPTION
Numpy has changed the default approach to implied casting. This fix is needed if you install the latest (1.10) numpy as I found on my mac.
