### PR TITLE
Zcontrol keys

### DIFF
--- a/gui/keyboard.py
+++ b/gui/keyboard.py
@@ -15,13 +15,13 @@ def setKeyboardHandlers(window):
         (wx.ACCEL_NORMAL, wx.WXK_NUMPAD_SUBTRACT, 6906), # Recentre fine motion
 
         # Move the stage with the keypad
-        (wx.ACCEL_NORMAL, wx.WXK_NUMPAD1, 6311), # Z down
+        (wx.ACCEL_NORMAL, wx.WXK_DOWN, 6311), # Z down
         (wx.ACCEL_NORMAL, wx.WXK_NUMPAD2, 6312), # Y down
         (wx.ACCEL_NORMAL, wx.WXK_NUMPAD3, 6313), # Decrease delta
         (wx.ACCEL_NORMAL, wx.WXK_NUMPAD4, 6314), # X up
         (wx.ACCEL_NORMAL, wx.WXK_NUMPAD5, 6315), # Stop motion
         (wx.ACCEL_NORMAL, wx.WXK_NUMPAD6, 6316), # X down
-        (wx.ACCEL_NORMAL, wx.WXK_NUMPAD7, 6317), # Z up
+        (wx.ACCEL_NORMAL, wx.WXK_UP, 6317), # Z up
         (wx.ACCEL_NORMAL, wx.WXK_NUMPAD8, 6318), # Y up
         (wx.ACCEL_NORMAL, wx.WXK_NUMPAD9, 6319), # Increase delta
 


### PR DESCRIPTION
Changes the Z control keys to be the cursor keys to try and prevent accidental Z control versus XY. 
