### PR TITLE
Added 'move to mouse' entry to secondary windows menu entries.

### DIFF
--- a/gui/keyboard.py
+++ b/gui/keyboard.py
@@ -115,6 +115,10 @@ def martialWindows(parent):
                 lambda event, window = window: (window.Restore() if window.IsIconized() 
                                                 else window.Show(not window.IsShown()) ) )
         menuId += 1
+        subMenu.Append(menuId, "Move to mouse")
+        wx.EVT_MENU(parent, menuId,
+                lambda event, window = window: window.SetPosition(wx.GetMousePosition()))
+        menuId += 1
         # Some windows have very long titles (e.g. the Macro Stage View),
         # so just take the first 50 characters.
         menu.AppendMenu(menuId, str(window.GetTitle())[:50], subMenu)


### PR DESCRIPTION
This adds the "move to mouse" menu entry for secondary windows as these can get lost as well. I think this is needed.
