### PR TITLE
Scale mosaic centerCanvas so that the current image fills roughly 25%…

### DIFF
--- a/gui/mosaic/window.py
+++ b/gui/mosaic/window.py
@@ -218,7 +218,7 @@ class MosaicWindow(wx.Frame):
         objective = depot.getHandlersOfType(depot.OBJECTIVE)[0]
         self.crosshairBoxSize = 512 * objective.getPixelSize()
         self.offset = objective.getOffset()
-        scale= (1/objective.getPixelSize())*0.5
+        scale = (1/objective.getPixelSize())*0.5
         self.canvas.zoomTo(-curPosition[0]+self.offset[0],
                            curPosition[1]-self.offset[1], scale)
 


### PR DESCRIPTION
… of screen

This make the mosaic find centre function scale so that the current objective image fills sensible segment of the screen.  
