### PR TITLE
Nanomover

### DIFF
--- a/devices/nanomover.py
+++ b/devices/nanomover.py
@@ -5,6 +5,7 @@ import gui.toggleButton
 import handlers.genericPositioner
 import handlers.stagePositioner
 import util.connection
+import interfaces
 
 import numpy
 import threading


### PR DESCRIPTION
This adds a nanomover device for stage positioning based on the UCSF device driver but updated to run on the current cockpit. Currently running on OMXv2 in Oxford. Also requires the nanomoverIII remote code as well.