### PR TITLE
hack to ensure pol-rot events dont overlap

### DIFF
--- a/cockpit/experiment/structuredIllumination.py
+++ b/cockpit/experiment/structuredIllumination.py
@@ -231,9 +231,9 @@ class SIExperiment(experiment.Experiment):
             curTime += decimal.Decimal('1e-6')
         if self.phaseHandler is not None:
             table.addAction(curTime, self.phaseHandler, 0)
-            curTime += decimal.Decimal('1e-6')
+            curTime += decimal.Decimal('1')
         table.addAction(curTime, self.zPositioner, self.zStart)
-        curTime += decimal.Decimal('1e-6')
+        curTime += decimal.Decimal('1')
 
         if self.slmHandler is not None:
             # Add a first trigger of the SLM to get first new image.


### PR DESCRIPTION
This is a hack to ensure we don't get 2 events at time 0 for the pol rotator. Probably not the best fix but ti works on CryoSIM. Fixes #335 