### PR TITLE
Cascading buttons

### DIFF
--- a/cockpit/devices/device.py
+++ b/cockpit/devices/device.py
@@ -59,6 +59,12 @@ class Device(object):
         'port': int,
     }
 
+
+    # Define __lt__ to make handlers sortable.
+    def __lt__(self, other):
+        return self.name.lower() < other.name.lower()
+
+
     def __init__(self, name='', config={}):
         ## Set to False to disable this device. Disabled devices will not be 
         # initialized on startup. 

--- a/cockpit/gui/device.py
+++ b/cockpit/gui/device.py
@@ -439,11 +439,10 @@ class OptionButtons(wx.Panel):
         super().__init__(*args, **kwargs)
         s = wx.BoxSizer(wx.VERTICAL)
         if label:
-            print ("ADDING LABEL")
             labelctrl = Label(parent=self, label=label)
             s.Add(labelctrl)
 
-        self.mainButton = Button(label='OBJECTIVE',
+        self.mainButton = Button(label='...',
                                  parent=self,
                                  size=TALL_SIZE)
         self.mainButton.Bind(wx.EVT_LEFT_UP, self.showButtons)

--- a/cockpit/gui/mainWindow.py
+++ b/cockpit/gui/mainWindow.py
@@ -180,14 +180,14 @@ class MainWindow(wx.Frame):
         otherThings = list(depot.getAllDevices())
         otherThings.sort(key = lambda d: d.__class__.__name__)
         otherThings.extend(depot.getAllHandlers())
-        # Make the UI elements for the cameras.
         rowSizer = wx.BoxSizer(wx.HORIZONTAL)
         hs = depot.getHandlersOfType(depot.OBJECTIVE)
         for h in hs:
             rowSizer.Add(h.makeUI(topPanel))
             rowSizer.AddSpacer(COL_SPACER)
         ignoreThings.extend(hs)
-        for camera in cameraThings:
+        # Make the UI elements for the cameras.
+        for camera in sorted(cameraThings):
             # Clear cameraUI so we don't use previous value.
             cameraUI = None
             # See if the camera has a function to make UI elements.
@@ -199,11 +199,23 @@ class MainWindow(wx.Frame):
             if cameraUI:
                 rowSizer.Add(cameraUI)
                 rowSizer.AddSpacer(COL_SPACER)
+        # Make UI elements for filters.
+        hs = sorted(depot.getHandlersOfType(depot.LIGHT_FILTER))
+        for i, h in enumerate(hs):
+            if i%2 == 0:
+                s = wx.BoxSizer(wx.VERTICAL)
+                rowSizer.Add(s)
+                rowSizer.AddSpacer(COL_SPACER)
+            else:
+                s.AddSpacer(ROW_SPACER)
+            s.Add(h.makeUI(topPanel))
+        rowSizer.AddSpacer(COL_SPACER)
+        ignoreThings.extend(hs)
         # Make the UI elements for eveything else.
         for thing in ignoreThings:
             if thing in otherThings:
                 otherThings.remove(thing)
-        for thing in otherThings:
+        for thing in sorted(otherThings):
             if depot.getHandler(thing, depot.CAMERA):
                 # Camera UIs already drawn.
                 continue
@@ -267,8 +279,6 @@ class MainWindow(wx.Frame):
                 # Put a spacer in so this widget has the same vertical size.
                 columnSizer.Add((-1, 1), 1, wx.EXPAND)
             lightUI = light.makeUI(lightPanel)
-            lightWidth = lightUI.GetSize()[0]
-                
             columnSizer.Add(lightUI)
             events.publish('create light controls', lightPanel,
                     columnSizer, light)

--- a/cockpit/gui/mainWindow.py
+++ b/cockpit/gui/mainWindow.py
@@ -180,11 +180,13 @@ class MainWindow(wx.Frame):
         otherThings = list(depot.getAllDevices())
         otherThings.sort(key = lambda d: d.__class__.__name__)
         otherThings.extend(depot.getAllHandlers())
-        for thing in ignoreThings: 
-            if thing in otherThings:
-                otherThings.remove(thing)
         # Make the UI elements for the cameras.
         rowSizer = wx.BoxSizer(wx.HORIZONTAL)
+        hs = depot.getHandlersOfType(depot.OBJECTIVE)
+        for h in hs:
+            rowSizer.Add(h.makeUI(topPanel))
+            rowSizer.AddSpacer(COL_SPACER)
+        ignoreThings.extend(hs)
         for camera in cameraThings:
             # Clear cameraUI so we don't use previous value.
             cameraUI = None
@@ -198,6 +200,9 @@ class MainWindow(wx.Frame):
                 rowSizer.Add(cameraUI)
                 rowSizer.AddSpacer(COL_SPACER)
         # Make the UI elements for eveything else.
+        for thing in ignoreThings:
+            if thing in otherThings:
+                otherThings.remove(thing)
         for thing in otherThings:
             if depot.getHandler(thing, depot.CAMERA):
                 # Camera UIs already drawn.

--- a/cockpit/handlers/deviceHandler.py
+++ b/cockpit/handlers/deviceHandler.py
@@ -152,6 +152,12 @@ class DeviceHandler(object):
         self.enableLock = threading.Lock()
         self.clear_cache = self.__cache.clear
 
+
+    # Define __lt__ to make handlers sortable.
+    def __lt__(self, other):
+        return self.name.lower() < other.name.lower()
+
+
     ## Return a string that identifies the device.
     def getIdentifier(self):
         return "%s:%s" % (self.deviceType, self.name)

--- a/cockpit/handlers/objective.py
+++ b/cockpit/handlers/objective.py
@@ -102,27 +102,15 @@ class ObjectiveHandler(deviceHandler.DeviceHandler):
 
     ## Generate a row of buttons, one for each possible objective.
     def makeUI(self, parent):
-        frame = wx.Frame(parent, title = "Objectives",
-                style = wx.RESIZE_BORDER | wx.CAPTION | wx.FRAME_TOOL_WINDOW)
-        panel = wx.Panel(frame)
-        sizer = wx.BoxSizer(wx.HORIZONTAL)
-        for name in sorted(self.nameToPixelSize.keys()):
-            colour = self.nameToColour.get(name)
-            colour= (colour[0]*255,colour[1]*255,colour[2]*255)
-            button = cockpit.gui.toggleButton.ToggleButton(
-                activeColor = colour,
-                label = name, parent = panel, 
-                size = (80, 40))
-            button.Bind(wx.EVT_LEFT_DOWN, 
-                    lambda event, name = name: self.changeObjective(name))
-            sizer.Add(button)
-            self.buttons.append(button)
-        panel.SetSizerAndFit(sizer)
-        frame.SetClientSize(panel.GetSize())
-        frame.SetPosition((2160, 0))
+        from cockpit.gui.device import OptionButtons
+        names = sorted(self.nameToPixelSize.keys())
+        frame = OptionButtons(parent, label="Objective")
         frame.Show()
-        cockpit.gui.keyboard.setKeyboardHandlers(frame)
-        return None
+        frame.setOptions(map(lambda name: (name,
+                                           lambda n=name: self.changeObjective(n)), names))
+
+        events.subscribe("objective change", lambda *a, **kw: frame.setOption(a[0]))
+        return frame
 
 
     ## Let everyone know what the initial objective.
@@ -139,10 +127,7 @@ class ObjectiveHandler(deviceHandler.DeviceHandler):
                 pixelSize=self.nameToPixelSize[newName], 
                 transform=self.nameToTransform[newName],
                 offset=self.nameToOffset[newName])				
-        targetIndex = sorted(self.nameToPixelSize.keys()).index(newName)
-        for i, button in enumerate(self.buttons):
-            button.setActive(i == targetIndex)
-                
+
 
     ## Get the current pixel size.
     def getPixelSize(self):


### PR DESCRIPTION
Added cascading mutually-exclusive option control, OptionButtons, like a drop-down, but using themed buttons to match other controls in the main panel.

* Replaced objectives window an OptionButtons control.
* Replaced filter button (and its popup menu) with OptionButtons control.
* Fixed position of objectives control before cameras.
* Fixed position of filter controls immediately after cameras, in name order.
* Cameras controls now in name order.
* Defined __lt__ on base device and base handler so that they can be sorted on name easily.