### PR TITLE
Set SLM to 0th image at end of SI experiment table.

### DIFF
--- a/cockpit/experiment/structuredIllumination.py
+++ b/cockpit/experiment/structuredIllumination.py
@@ -334,6 +334,11 @@ class SIExperiment(experiment.Experiment):
             table.addAction(curTime, self.polarizerHandler, (0, 'default'))
             finalWaitTime = finalWaitTime + decimal.Decimal(1e-6)
 
+        # Set SLM back to 0th image ready for next measurement in timelapse or multi-site.
+        if self.slmHandler is not None:
+            # Toggle the slmHandler's digital line handler to advance one frame.
+            table.addToggle(curTime, self.slmHandler)
+
         return table
 
 


### PR DESCRIPTION
Adds a toggle of the SLM handler to the end of SI experiment action tables. Should work for both 3D and 2D SIM, because the 2D case subclasses 3D.