### PR TITLE
Fixed axis order in getPosition.

### DIFF
--- a/cockpit/interfaces/stageMover.py
+++ b/cockpit/interfaces/stageMover.py
@@ -402,11 +402,10 @@ def loadSites(filename):
 ## Return the exact stage position, as the aggregate of all handlers'
 # positions.
 def getPosition():
-    result = []
+    result = 3 * [0]
     for axis, handlers in iteritems(mover.axisToHandlers):
-        result.append(0)
         for handler in handlers:
-            result[-1] += handler.getPosition()
+            result[axis] += handler.getPosition()
     return result
 
 


### PR DESCRIPTION
Fixes #318. The stage was 'moving' correctly, but the axis mapping was wrong in the mosaic display. getPosition was iterating over a dict to produce a list; it assumed that iteration order would match axis order, which is not guaranteed.