### PR TITLE
Fix overflow error by wrapping non-python types.

### DIFF
--- a/cockpit/experiment/dataSaver.py
+++ b/cockpit/experiment/dataSaver.py
@@ -148,7 +148,7 @@ class DataSaver:
 
         ## Number of bytes to allocate for each image in the file.
         # \todo Assuming unsigned 16-bit integer here.
-        self.planeBytes = (self.maxWidth * self.maxHeight * 2)
+        self.planeBytes = int(self.maxWidth * self.maxHeight * 2)
 
         ## Number of timepoints per file, based on the above and
         # self.maxFilesize.
@@ -443,7 +443,7 @@ class DataSaver:
         ## for the plane data in the image section.  1024 is the
         ## length of the base header.
         metadataOffset = 1024 + (planeIndex * self.extendedBytes)
-        dataOffset = (1024 + self.headers[fileIndex].next
+        dataOffset = (1024 + int(self.headers[fileIndex].next)
                       + (planeIndex * self.planeBytes))
 
         height, width = imageData.shape


### PR DESCRIPTION
Fixes #365.

One or more operands in the calculation of dataOffset are int32 rather
than a python int. This causes an overflow error when the value of
dataOffset exceeded 2**31-1, meaning that data beyond 2Gb in any
experiment is lost. Wrapping these operands with int() solves this
problem.

planeBytes is wrapped once, on assignment.

I think headers[fileIndex].next has to be wrapped each time, as this
value can be reassigned by util.Mrc. We should perhaps fix this in Mrc.py.