### PR TITLE
Ensure triggered light sources are off after abort.

### DIFF
--- a/cockpit/handlers/lightSource.py
+++ b/cockpit/handlers/lightSource.py
@@ -130,6 +130,12 @@ class LightHandler(deviceHandler.DeviceHandler):
         events.subscribe('save exposure settings', self.onSaveSettings)
         events.subscribe('load exposure settings', self.onLoadSettings)
         events.subscribe('light exposure update', self.setLabel)
+        # Most lasers use bulb-type triggering. Ensure they're not left on after
+        # an abort event.
+        if trigHandler and trigLine:
+            onAbort = lambda *args: trigHandler.setDigital(trigLine, False)
+            events.subscribe('user abort', onAbort)
+
 
     ## Save our settings in the provided dict.
     def onSaveSettings(self, settings):


### PR DESCRIPTION
Fixes #341.

If a light source has a trigger handler and a trigger line, then a subscription is set up to set that trigger line low on a 'user abort' event.

Tested with the 488 on deepsim.