### PR TITLE
Mosaic scale fix

### DIFF
--- a/cockpit/gui/mosaic/window.py
+++ b/cockpit/gui/mosaic/window.py
@@ -284,7 +284,7 @@ class MosaicWindow(wx.Frame):
         if (self.crosshairBoxSize == 0):
             self.crosshairBoxSize = 512 * objective.getPixelSize()
         self.offset = objective.getOffset()
-        scale = (1/objective.getPixelSize())*(10./self.crosshairBoxSize)
+        scale = (150./self.crosshairBoxSize)
         self.canvas.zoomTo(-curPosition[0]+self.offset[0],
                            curPosition[1]-self.offset[1], scale)
 

--- a/cockpit/gui/touchscreen/touchscreen.py
+++ b/cockpit/gui/touchscreen/touchscreen.py
@@ -572,7 +572,7 @@ class TouchScreenWindow(wx.Frame):
         if (self.crosshairBoxSize == 0):
             self.crosshairBoxSize = 512 * objective.getPixelSize()
         self.offset = objective.getOffset()
-        scale = (1/objective.getPixelSize())*(10./self.crosshairBoxSize)
+        scale = (150./self.crosshairBoxSize)
         self.canvas.zoomTo(-curPosition[0]+self.offset[0],
                            curPosition[1]-self.offset[1], scale)
 


### PR DESCRIPTION
Fix the mosaic and touchscreen "find stage" functions so they always give you the current field of view centred at the reasonable scale.