### PR TITLE
Mode buttons

### DIFF
--- a/cockpit/devices/linkamStage.py
+++ b/cockpit/devices/linkamStage.py
@@ -93,8 +93,8 @@ class LinkamStage(stage.StageDevice):
         events.subscribe('load exposure settings', self.onLoadSettings)
 
 
-     ## Save our settings in the provided dict.
-     def onSaveSettings(self, settings):
+    ## Save our settings in the provided dict.
+    def onSaveSettings(self, settings):
          #hack as no way to read state at the momnent. Need to FIX.
          settings[self.name] = {'condensor': 0 }
 

--- a/cockpit/devices/linkamStage.py
+++ b/cockpit/devices/linkamStage.py
@@ -88,8 +88,25 @@ class LinkamStage(stage.StageDevice):
             self.softlimits = DEFAULT_LIMITS
         events.subscribe('user logout', self.onLogout)
         events.subscribe('user abort', self.onAbort)
+        #store and recall condensor LED status.
+        events.subscribe('save exposure settings', self.onSaveSettings)
+        events.subscribe('load exposure settings', self.onLoadSettings)
 
 
+     ## Save our settings in the provided dict.
+     def onSaveSettings(self, settings):
+         #hack as no way to read state at the momnent. Need to FIX.
+         settings[self.name] = {'condensor': 0 }
+
+    ## Load our settings from the provided dict.
+    def onLoadSettings(self, settings):
+        if self.name in settings:
+            #Only chnbage settings if needed.
+            if settings[self.name]['condensor']:
+                self.condensorOn()
+            else:
+                self.condensorOff()
+       
     def finalizeInitialization(self):
         """Finalize device initialization."""
         self.statusThread = threading.Thread(target=self.pollStatus)

--- a/cockpit/devices/linkamStage.py
+++ b/cockpit/devices/linkamStage.py
@@ -106,7 +106,7 @@ class LinkamStage(stage.StageDevice):
                 self.condensorOn()
             else:
                 self.condensorOff()
-       
+
     def finalizeInitialization(self):
         """Finalize device initialization."""
         self.statusThread = threading.Thread(target=self.pollStatus)

--- a/cockpit/gui/camera/window.py
+++ b/cockpit/gui/camera/window.py
@@ -85,8 +85,6 @@ class CamerasWindow(wx.Frame):
 
         events.subscribe("camera enable", self.onCameraEnableEvent)
         events.subscribe("image pixel info", self.onImagePixelInfo)
-        events.subscribe('save exposure settings', self.onSaveSettings)
-        events.subscribe('load exposure settings', self.onLoadSettings)
         cockpit.gui.keyboard.setKeyboardHandlers(self)
 
         self.Bind(wx.EVT_CLOSE, self.onClose)
@@ -101,25 +99,6 @@ class CamerasWindow(wx.Frame):
         events.publish('program exit')
         event.Skip()
 
-
-    ## Save our settings in the provided dict.
-    def onSaveSettings(self, settings):
-        settings['camera view window'] = []
-        for view in self.views:
-            if view.curCamera is not None:
-                settings['camera view window'].append(view.curCamera.name)
-
-
-    ## Load our settings from the provided dict.
-    def onLoadSettings(self, settings):
-        # This code breaks as the views dont nessecarily exist.
-        # now subscribing from individual cameras.
-#        for view in self.views:
-#            view.disableCamera()
-#        for i, camName in enumerate(settings.get('camera view window', [])):
-#            camera = depot.getHandlerWithName(camName)
-#            self.views[i].enableCamera(camera)
-        pass
 
     @cockpit.util.threads.callInMainThread
     def onCameraEnableEvent(self, camera, enabled):

--- a/cockpit/gui/camera/window.py
+++ b/cockpit/gui/camera/window.py
@@ -112,12 +112,14 @@ class CamerasWindow(wx.Frame):
 
     ## Load our settings from the provided dict.
     def onLoadSettings(self, settings):
-        for view in self.views:
-            view.disableCamera()
-        for i, camName in enumerate(settings.get('camera view window', [])):
-            camera = depot.getHandlerWithName(camName)
-            self.views[i].enableCamera(camera)
-
+        # This code breaks as the views dont nessecarily exist.
+        # now subscribing from individual cameras.
+#        for view in self.views:
+#            view.disableCamera()
+#        for i, camName in enumerate(settings.get('camera view window', [])):
+#            camera = depot.getHandlerWithName(camName)
+#            self.views[i].enableCamera(camera)
+        pass
 
     @cockpit.util.threads.callInMainThread
     def onCameraEnableEvent(self, camera, enabled):

--- a/cockpit/gui/device.py
+++ b/cockpit/gui/device.py
@@ -493,6 +493,7 @@ class OptionButtons(wx.Panel):
         # Set buttons with options = [(label, callback or None), ...]
         for b in self.buttons:
             del (b)
+        self.subframe.Sizer.Clear()
         for label, callback in options:
             b = Button(label=label, parent=self.subframe, size=self.size)
             b.Bind(wx.EVT_LEFT_UP, lambda evt, b=b, c=callback: self.onButton(b, c))

--- a/cockpit/gui/mainWindow.py
+++ b/cockpit/gui/mainWindow.py
@@ -151,18 +151,14 @@ class MainWindow(wx.Frame):
         self.videoButton.Bind(wx.EVT_LEFT_DOWN,
                 lambda event: cockpit.interfaces.imager.videoMode())
         buttonSizer.Add(self.videoButton)
-        self.storeButton =  OptionButtons(parent= topPanel)
+        self.storeButton =  OptionButtons(parent= topPanel, label = "Store/Recall",
+                )
         
         self.storeButton.setOptions (map(lambda name: (name,
                                                        lambda n=name:
                                                        self.setMode(n)),
                                          self.storedModes))
         buttonSizer.Add(self.storeButton)
-        loadButton = toggleButton.ToggleButton(textSize = 12,
-                label = "Recall Exposure\nSettings",
-                size = (120, 80), parent = topPanel)
-        loadButton.Bind(wx.EVT_LEFT_DOWN, self.onLoadExposureSettings)        
-        buttonSizer.Add(loadButton)
         snapButton = toggleButton.ToggleButton(textSize = 12,
                 label = "Snap",
                 size = (120, 80), parent = topPanel)

--- a/cockpit/gui/mainWindow.py
+++ b/cockpit/gui/mainWindow.py
@@ -151,13 +151,13 @@ class MainWindow(wx.Frame):
         self.videoButton.Bind(wx.EVT_LEFT_DOWN,
                 lambda event: cockpit.interfaces.imager.videoMode())
         buttonSizer.Add(self.videoButton)
-        self.storeButton =  OptionButtons(parent= topPanel, label = "Store/Recall",
-                )
+        self.storeButton =  OptionButtons(parent= topPanel,size=(120, 80))
         
         self.storeButton.setOptions (map(lambda name: (name,
                                                        lambda n=name:
                                                        self.setMode(n)),
                                          self.storedModes))
+        self.storeButton.mainButton.SetLabel(text='Config\npath')
         buttonSizer.Add(self.storeButton)
         snapButton = toggleButton.ToggleButton(textSize = 12,
                 label = "Snap",

--- a/cockpit/gui/mainWindow.py
+++ b/cockpit/gui/mainWindow.py
@@ -157,7 +157,7 @@ class MainWindow(wx.Frame):
                                                        lambda n=name:
                                                        self.setMode(n)),
                                          self.storedModes))
-        self.storeButton.mainButton.SetLabel(text='Config\npath')
+        self.storeButton.mainButton.SetLabel(text='Path')
         buttonSizer.Add(self.storeButton)
         snapButton = toggleButton.ToggleButton(textSize = 12,
                 label = "Snap",
@@ -382,7 +382,7 @@ class MainWindow(wx.Frame):
         # abuse get value dialog which will also return a string. 
         value = cockpit.gui.dialogs.getNumberDialog.getNumberFromUser(
             parent=self.topPanel, default='', title='New Mode Name',
-            prompt='Name')
+            prompt='Name', atMouse=True)
         self.storedModes[value]=dict()
         #publish an event to populate mode settings.
         events.publish('save exposure settings', self.storedModes[value])

--- a/cockpit/gui/mainWindow.py
+++ b/cockpit/gui/mainWindow.py
@@ -58,6 +58,7 @@ from __future__ import absolute_import
 
 import json
 import wx
+import os.path
 
 from cockpit import depot
 from .dialogs.experiment import multiSiteExperiment
@@ -422,7 +423,6 @@ class MainWindow(wx.Frame):
     ## User wants to load an old set of exposure settings; get a file path
     # to load from, and publish an event with the data.
     def onLoadExposureSettings(self, event = None):
-        import os.path
         dialog = wx.FileDialog(self, style = wx.FD_OPEN, wildcard = '*.txt',
                 message = "Please select the settings file to load.",
                 defaultDir = cockpit.util.user.getUserSaveDir())

--- a/cockpit/handlers/camera.py
+++ b/cockpit/handlers/camera.py
@@ -130,6 +130,22 @@ class CameraHandler(deviceHandler.DeviceHandler):
                     "%s imager" % name, "imager",
                     {'takeImage': softTrigger}))
 
+        #subscribe to save and load setting calls to enabvle saving and
+        #loading of configurations.
+        events.subscribe('save exposure settings', self.onSaveSettings)
+        events.subscribe('load exposure settings', self.onLoadSettings)
+
+
+    ## Save our settings in the provided dict.
+    def onSaveSettings(self, settings):
+        settings[self.name] = self.getIsEnabled()
+
+    ## Load our settings from the provided dict.
+    def onLoadSettings(self, settings):
+        if self.name in settings:
+            # only chnage state if we need to as this is slow
+            if (self.getIsEnabled() != settings[self.name]):
+                self.setEnabled(settings[self.name])
 
     @property
     def color(self):

--- a/cockpit/handlers/camera.py
+++ b/cockpit/handlers/camera.py
@@ -144,7 +144,7 @@ class CameraHandler(deviceHandler.DeviceHandler):
     def onLoadSettings(self, settings):
         if self.name in settings:
             # only chnage state if we need to as this is slow
-            if (self.getIsEnabled() != settings[self.name]):
+            if self.getIsEnabled() != settings[self.name]:
                 self.setEnabled(settings[self.name])
 
     @property

--- a/cockpit/handlers/filterHandler.py
+++ b/cockpit/handlers/filterHandler.py
@@ -45,6 +45,7 @@ class Filter(object):
             self.label = args[0]
             self.value = args[1]
 
+            
     def __repr__(self):
         if self.value:
             return '%d: %s, %s' % (self.position, self.label, self.value)
@@ -63,6 +64,22 @@ class FilterHandler(deviceHandler.DeviceHandler):
         self.cameras = cameras or []
         self.lights = lights or []
 
+        #subscribe to save and load setting calls to enabvle saving and
+        #loading of configurations.
+        events.subscribe('save exposure settings', self.onSaveSettings)
+        events.subscribe('load exposure settings', self.onLoadSettings)
+
+
+    ## Save our settings in the provided dict.
+    def onSaveSettings(self, settings):
+        settings[self.name] = self.currentFilter()
+
+    ## Load our settings from the provided dict.
+    def onLoadSettings(self, settings):
+        if self.name in settings:
+            self.setFilter(settings[self.name])
+
+        
 
     ### UI functions ####
     def makeUI(self, parent):

--- a/cockpit/handlers/lightSource.py
+++ b/cockpit/handlers/lightSource.py
@@ -150,7 +150,7 @@ class LightHandler(deviceHandler.DeviceHandler):
             #Only chnbage settings if needed.
             if (self.getExposureTime != settings[self.name]['exposureTime']):
                 self.setExposureTime(settings[self.name]['exposureTime'])
-            if (self.getIs Enabled != settings[self.name]['isEnabled']):
+            if (self.getIsEnabled != settings[self.name]['isEnabled']):
                 self.setEnabled(settings[self.name]['isEnabled'])
 
 

--- a/cockpit/handlers/lightSource.py
+++ b/cockpit/handlers/lightSource.py
@@ -147,8 +147,11 @@ class LightHandler(deviceHandler.DeviceHandler):
     ## Load our settings from the provided dict.
     def onLoadSettings(self, settings):
         if self.name in settings:
-            self.setExposureTime(settings[self.name]['exposureTime'])
-            self.setEnabled(settings[self.name]['isEnabled'])
+            #Only chnbage settings if needed.
+            if (self.getExposureTime != settings[self.name]['exposureTime']):
+                self.setExposureTime(settings[self.name]['exposureTime'])
+            if (self.getIs Enabled != settings[self.name]['isEnabled']):
+                self.setEnabled(settings[self.name]['isEnabled'])
 
 
     ## Turn the laser on, off, or set continuous exposure.

--- a/cockpit/handlers/lightSource.py
+++ b/cockpit/handlers/lightSource.py
@@ -148,9 +148,9 @@ class LightHandler(deviceHandler.DeviceHandler):
     def onLoadSettings(self, settings):
         if self.name in settings:
             #Only chnbage settings if needed.
-            if (self.getExposureTime != settings[self.name]['exposureTime']):
+            if self.getExposureTime != settings[self.name]['exposureTime']:
                 self.setExposureTime(settings[self.name]['exposureTime'])
-            if (self.getIsEnabled != settings[self.name]['isEnabled']):
+            if self.getIsEnabled != settings[self.name]['isEnabled']:
                 self.setEnabled(settings[self.name]['isEnabled'])
 
 


### PR DESCRIPTION
This pull request deals with storing and recalling "modes" which is an active configuration of which cameras and light sources are on, light source exposure and power level (if it exists) and filter wheel settings. This allows single press switching between different configs, eg moving from transmission to dual channel fluorescence. 

Outstanding issues:
1) Deal with loading from disk
2) use channel name as default file name, and file name as default channel name (-.txt). 
3) mechanism to update a given mode to the current config rather than just create a new one.
4) button size and maybe label needs improving.