### PR TITLE
Repeat duration warning

### DIFF
--- a/cockpit/experiment/experiment.py
+++ b/cockpit/experiment/experiment.py
@@ -216,7 +216,17 @@ class Experiment:
                 self.cameraToIsReady[camera] = False
 
         self.createValidActionTable()
+        if self.numReps > 1 and self.repDuration < self.table.lastActionTime / 1000:
+            warning = "Repeat duration is less than the time required to run " \
+                      "one repeat. Choose:" \
+                      "\n    'OK' to run repeats as fast as possible;" \
+                      "\n    'Cancel' to go back and change parameters."
+            if not guiUtils.getUserPermission(warning):
+                return False
 
+
+        # ToDo: check duration of action table against timelapse settings
+        # display appropriate warnings.
         self.lastMinuteActions()
 
         runThread = threading.Thread(target = self.execute)

--- a/cockpit/experiment/experiment.py
+++ b/cockpit/experiment/experiment.py
@@ -190,12 +190,13 @@ class Experiment:
     ## Run the experiment. We spin off the actual execution and cleanup
     # into separate threads.
     def run(self):
+        # Returns True to close config dialog box, False or None otherwise.
         # Check if the user is set to save to an already-existing file.
         if self.savePath and os.path.exists(self.savePath):
             if not guiUtils.getUserPermission(
                     ("The file:\n%s\nalready exists. " % self.savePath) +
                     "Are you sure you want to overwrite it?"):
-                return
+                return False
 
         global lastExperiment
         lastExperiment = self
@@ -257,6 +258,7 @@ class Experiment:
         runThread.start()
         # Start up a thread to clean up after the experiment finishes.
         threading.Thread(target = self.cleanup, args = [runThread, saveThread]).start()
+        return True
 
     ## Create an ActionTable by calling self.generateActions, and give our
     # Devices a chance to sign off on it.

--- a/cockpit/gui/dialogs/experiment/experimentConfigPanel.py
+++ b/cockpit/gui/dialogs/experiment/experimentConfigPanel.py
@@ -439,6 +439,7 @@ class ExperimentConfigPanel(wx.Panel):
 
     ## Run the experiment per the user's settings.
     def runExperiment(self):
+        # Returns True to close dialog box, None or False otherwise.
         self.saveSettings()
         # Find the Z mover with the smallest range of motion, assumed
         # to be our experiment mover.
@@ -452,7 +453,7 @@ class ExperimentConfigPanel(wx.Panel):
             wx.MessageDialog(self,
                     message = "No cameras are enabled, so the experiment cannot be run.",
                     style = wx.ICON_EXCLAMATION | wx.STAY_ON_TOP | wx.OK).ShowModal()
-            return
+            return True
         lights = list(filter(lambda l: l.getIsEnabled(),
                 depot.getHandlersOfType(depot.LIGHT_TOGGLE)))
         
@@ -516,7 +517,7 @@ class ExperimentConfigPanel(wx.Panel):
             params = self.experimentModuleToPanel[module].augmentParams(params)
 
         self.runner = module.EXPERIMENT_CLASS(**params)
-        self.runner.run()
+        return self.runner.run()
 
 
     ## Generate a dict of our current settings.

--- a/cockpit/gui/dialogs/experiment/singleSiteExperiment.py
+++ b/cockpit/gui/dialogs/experiment/singleSiteExperiment.py
@@ -127,12 +127,7 @@ class SingleSiteExperimentDialog(wx.Dialog):
         self.statusbar.SetLabel('')
         if not self.Validate():
             return
-        message = self.panel.runExperiment()
-        if message is not None:
-            wx.MessageBox("The experiment cannot be run:\n%s" % message,
-                    "Error", wx.OK | wx.ICON_ERROR | wx.STAY_ON_TOP)
-            return
-        else:
+        if self.panel.runExperiment():
             self.Hide()
 
 


### PR DESCRIPTION
Adds a warning if repeat duration is less than the time required to execute one repeat, and asks the user whether to continue or go back to change parameters.