### PR TITLE
fix on limits check for move to top/bottom/centre

### DIFF
--- a/cockpit/gui/saveTopBottomPanel.py
+++ b/cockpit/gui/saveTopBottomPanel.py
@@ -183,9 +183,14 @@ def moveZCheckMoverLimits(target):
     currentPos= cockpit.interfaces.stageMover.getPosition()[2]
     offset = target - currentPos
 
+
+    ##IMD 2018-11-07 I think this test needs to be currentpos of the
+    ##current mover not the overall pos.
     while (cockpit.interfaces.stageMover.mover.curHandlerIndex >= 0):
-        if ((currentPos + offset)> limits[cockpit.interfaces.stageMover.mover.curHandlerIndex][1] or
-            (currentPos + offset) < limits[cockpit.interfaces.stageMover.mover.curHandlerIndex][0]):
+        handler=cockpit.interfaces.stageMover.mover.curHandlerIndex
+        moverPos=cockpit.interfaces.stageMover.getAllPositions()[handler][2]
+        if ((moverPos + offset)> limits[cockpit.interfaces.stageMover.mover.curHandlerIndex][1] or
+            (moverPos + offset) < limits[cockpit.interfaces.stageMover.mover.curHandlerIndex][0]):
             # need to drop down a handler to see if next handler can do the move
             cockpit.interfaces.stageMover.mover.curHandlerIndex -= 1
             if (cockpit.interfaces.stageMover.mover.curHandlerIndex < 0):


### PR DESCRIPTION
This means the current mover is used if possible then larger range movers till the largest.