### PR TITLE
Mosaic scale fix

### DIFF
--- a/cockpit/gui/camera/viewPanel.py
+++ b/cockpit/gui/camera/viewPanel.py
@@ -221,6 +221,9 @@ class ViewPanel(wx.Panel):
     ## Get the black- and white-point for the view.
     def getScaling(self):
         return self.canvas.getScaling()
+## Get the black- and white-point for the view.
+    def getCurrentScaling(self):
+        return self.canvas.getCurrentScaling()
 
 
     ## As above, but the relative values used to generate them instead.

--- a/cockpit/gui/camera/window.py
+++ b/cockpit/gui/camera/window.py
@@ -178,6 +178,13 @@ def getCameraScaling(camera):
             return view.getScaling()
     raise RuntimeError("Tried to get camera scalings for non-active camera [%s]" % camera.name)
 
+def getCurrentCameraScaling(camera):
+    for view in window.views:
+        if view.curCamera is camera:
+            return view.getCurrentScaling()
+    raise RuntimeError("Tried to get camera scalings for non-active camera [%s]" % camera.name)
+
+
 
 ## As above, but get the relative values used to generate the black/whitepoints.
 def getRelativeCameraScaling(camera):

--- a/cockpit/gui/imageViewer/viewCanvas.py
+++ b/cockpit/gui/imageViewer/viewCanvas.py
@@ -354,6 +354,12 @@ class ViewCanvas(wx.glcanvas.GLCanvas):
         return (self.blackPoint * imageRange + self.imageMin,
                 self.whitePoint * imageRange + self.imageMin)
 
+    def getCurrentScaling(self):
+        if self.imageData is None or len(self.tiles) == 0:
+            # No image to operate on yet.
+            return (None, None)
+        return(self.tiles[0][0].imageMin, self.tiles[0][0].imageMax)
+
 
     ## As above, but the values used to calculate them instead of the
     # absolute pixel values (e.g. (.1, .9) instead of (100, 400).

--- a/cockpit/gui/mosaic/window.py
+++ b/cockpit/gui/mosaic/window.py
@@ -768,7 +768,7 @@ class MosaicWindow(wx.Frame, MosaicCommon):
             # Get the scaling for the camera we're using, since they may
             # have changed.
             try:
-                minVal, maxVal = cockpit.gui.camera.window.getCameraScaling(camera)
+                minVal, maxVal = cockpit.gui.camera.window.getCurrentCameraScaling(camera)
             except Exception as e:
                 # Go to idle state.
                 self.shouldContinue.clear()
@@ -826,7 +826,7 @@ class MosaicWindow(wx.Frame, MosaicCommon):
                                     y-self.offset[1] - height / 2,
                                     z-self.offset[2]),
                 (width, height),
-                scalings = cockpit.gui.camera.window.getCameraScaling(camera))
+                scalings = cockpit.gui.camera.window.getCurrentCameraScaling(camera))
         self.Refresh()
 
     def togglescalebar(self):
@@ -1146,7 +1146,7 @@ class MosaicWindow(wx.Frame, MosaicCommon):
     # camera's display's black- and white-points.
     @_pauseMosaicLoop
     def rescaleWithCamera(self, camera):
-        self.canvas.rescale(cockpit.gui.camera.window.getCameraScaling(camera))
+        self.canvas.rescale(cockpit.gui.camera.window.getCurrentCameraScaling(camera))
 
 
     ## Save the mosaic to disk. We generate a text file describing the


### PR DESCRIPTION
This pulls the displayed scaling from the camera view panel rather than the current image min/max values. Adds a number of getCurrentScaling functions based on the exisiting getScaling functions. 