### PR TITLE
Stuck with glsl 120 on Mac.

### DIFF
--- a/cockpit/gui/imageViewer/viewCanvas.py
+++ b/cockpit/gui/imageViewer/viewCanvas.py
@@ -86,8 +86,8 @@ HISTOGRAM_HEIGHT = 40
 class BaseGL():
     # Default vertex shader glsl source
     _VS = """
-    #version 130
-    in vec2 vXY;
+    #version 120
+    attribute vec2 vXY;
     void main() {
         gl_Position = vec4(vXY, 1, 1);
         gl_FrontColor = gl_Color;
@@ -130,8 +130,8 @@ class Image(BaseGL):
     """
     # Vertex shader glsl source
     _VS = """
-    #version 130
-    in vec2 vXY;
+    #version 120
+    attribute vec2 vXY;
     uniform float zoom;
     uniform float angle;
     uniform vec2 pan;
@@ -143,7 +143,7 @@ class Image(BaseGL):
     """
     # Fragment shader glsl source
     _FS = """
-    #version 130
+    #version 120
     uniform sampler2D tex;
     uniform float scale;
     uniform float offset;
@@ -151,7 +151,7 @@ class Image(BaseGL):
     void main()
     {
         vec4 lum = clamp(offset + texture2D(tex, gl_TexCoord[0].st) / scale, 0., 1.);
-        gl_FragColor = vec4(0., 0., lum.g == 0, 1.) + vec4(1., lum.g < 1., 1., 1.) * lum;
+        gl_FragColor = vec4(0., 0., lum.r == 0, 1.) + vec4(1., lum.r < 1., 1., 1.) * lum.r;
     }
     """
 
@@ -249,10 +249,10 @@ class Image(BaseGL):
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-            glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, tx, ty, 0,
-                         GL_LUMINANCE, GL_FLOAT, None)
+            glTexImage2D(GL_TEXTURE_2D, 0, GL_RED, tx, ty, 0,
+                         GL_RED, GL_FLOAT, None)
             glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, subdata.shape[1], subdata.shape[0],
-                            GL_LUMINANCE, GL_FLOAT, subdata)
+                            GL_RED, GL_FLOAT, subdata)
         self._update = False
 
     def draw(self, pan=(0,0), zoom=1):

--- a/cockpit/gui/mosaic/tile.py
+++ b/cockpit/gui/mosaic/tile.py
@@ -129,7 +129,7 @@ class Tile:
         if imgType not in dtypeToGlTypeMap:
             raise ValueError("Unsupported data mode %s" % str(imgType))
         glTexImage2D(GL_TEXTURE_2D,0,  GL_RGB, tex_nx,tex_ny, 0, 
-                     GL_LUMINANCE, dtypeToGlTypeMap[imgType], None)    
+                     GL_LUMINANCE, dtypeToGlTypeMap[imgType], None)
 
 
     def refresh(self):
@@ -182,7 +182,7 @@ class Tile:
         if imgType not in dtypeToGlTypeMap:
             raise ValueError("Unsupported data mode %s" % str(imgType))
         glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, pic_nx, pic_ny,  
-                     GL_LUMINANCE, dtypeToGlTypeMap[imgType], imgString)  
+                     GL_LUMINANCE, dtypeToGlTypeMap[imgType], imgString)
 
 
     ## Free up memory we were using.


### PR DESCRIPTION
* Can't set context attributes to set GL 3.0 Core Profile.
* Using glsl 120 in the shaders.
* Replace deprecated GL_LUMINANCE with GL_RED where using shaders.

I was using glsl 1.30, which requires OpenGL 3.0.  On the Mac, you're stuck with OpenGL 2.1, unless you explicitly request an OpenGL Core Profile context. It looks like this became possible in wxWidgets fairly recently (using a wxGLContextAttrs object) , but is not yet possible in wxPython.