### PR TITLE
Some minor fixes and tweaks to device handlers

### DIFF
--- a/cockpit/gui/device.py
+++ b/cockpit/gui/device.py
@@ -210,7 +210,8 @@ _BMP_ERR = wx.Bitmap.FromRGBA(*_BMP_SIZE, red=255, green=0, blue=0,
 _BMPS = {STATES.enabling: _BMP_WAIT,
         STATES.enabled: _BMP_ON,
         STATES.disabled: _BMP_OFF,
-        STATES.error: _BMP_ERR}
+        STATES.error: _BMP_ERR,
+        None: _BMP_ERR}
 
 class EnableButton(wx.ToggleButton):
     def __init__(self, parent, deviceHandler):

--- a/cockpit/handlers/deviceHandler.py
+++ b/cockpit/handlers/deviceHandler.py
@@ -226,15 +226,7 @@ class DeviceHandler(object):
 
 
     ## Add a watch on a device parameter.
-    def addWatch(self, attrOrName, callback):
-        if isinstance(attrOrName, str):
-            name = attrOrName
-        else:
-            # may have been passed an attribute rather than its name
-            try:
-                name = next(filter(lambda x: attrOrName is x[1], self.__dict__.items()))[0]
-            except:
-                raise Exception("Could not find passed attribute on %s." % self)
+    def addWatch(self, name, callback):
         if name not in self._watches:
             self._watches[name] = set()
         self._watches[name].add(callback)

--- a/cockpit/handlers/deviceHandler.py
+++ b/cockpit/handlers/deviceHandler.py
@@ -238,20 +238,23 @@ class DeviceHandler(object):
         if self.state == STATES.enabling:
             # Already processing a previous toggle request.
             return
-        if not all([hasattr(self, 'setEnabled'), hasattr(self, 'getIsEnabled')]):
+        getIsEnabled = getattr(self, 'getIsEnabled', None) or self.callbacks.get('getIsEnabled', None)
+        setEnabled = getattr(self, 'setEnabled', None) or self.callbacks.get('setEnabled', None)
+        if not all([getIsEnabled, setEnabled]):
             raise Exception('toggleState dependencies not implemented for %s.' % self.name)
+
         # Do nothing if lock locked as en/disable already in progress.
         if not self.enableLock.acquire(False):
             return
         events.publish(events.DEVICE_STATUS, self, STATES.enabling)
         try:
-            self.setEnabled(not(self.getIsEnabled()))
+            setEnabled(not(getIsEnabled()))
         except Exception as e:
             events.publish(events.DEVICE_STATUS, self, STATES.error)
             raise Exception('Problem encountered en/disabling %s:\n%s' % (self.name, e))
         finally:
             self.enableLock.release()
-        events.publish(events.DEVICE_STATUS, self, self.getIsEnabled())
+        events.publish(events.DEVICE_STATUS, self, getIsEnabled())
 
     ## Add a toggle event to the action table.
     # Return time of last action, and response time before ready after trigger.

--- a/cockpit/handlers/filterHandler.py
+++ b/cockpit/handlers/filterHandler.py
@@ -92,7 +92,7 @@ class FilterHandler(deviceHandler.DeviceHandler):
         ctrl = wx.Choice(parent)
         ctrl.Set(list(map(str, self.filters)))
         ctrl.Bind(wx.EVT_CHOICE, lambda evt: self.setFilter(self.filters[evt.Selection]))
-        self.addWatch(self.lastFilter, lambda f: ctrl.SetSelection(ctrl.FindString(str(f))))
+        self.addWatch('lastFilter', lambda f: ctrl.SetSelection(ctrl.FindString(str(f))))
         ctrl.SetSelection(ctrl.FindString(str(self.lastFilter)))
         return ctrl
 


### PR DESCRIPTION
* Handles the case where a remote enable call returns None - rather than raising an IndexError, it displays an error state on the enable button.

* Removes broken logic that tries to determine an attribute from only its value, and so can match the wrong attribute.

* Allows getIsEnabled and setEnabled to reside on a handler or in its callbacks, so that devices can add the requirements for an en/disable button without creating a different type of handler, and without directly setting attributes on a handler.