### PR TITLE
Fixes for non-square images

### DIFF
--- a/cockpit/devices/camera.py
+++ b/cockpit/devices/camera.py
@@ -58,7 +58,7 @@ from . import device
 def Transform(tstr=None):
     """Desribes a simple transform: (flip LR, flip UD, rotate 90)"""
     if tstr:
-        return tuple([bool(t) for t in tstr.strip('()').split(',')])
+        return tuple([bool(int(t)) for t in tstr.strip('()').split(',')])
     else:
         return (False, False, False)
 

--- a/cockpit/devices/microscopeCamera.py
+++ b/cockpit/devices/microscopeCamera.py
@@ -244,8 +244,9 @@ class MicroscopeCamera(MicroscopeBase, camera.CameraDevice):
 
     def getImageSize(self, name):
         """Read the image size from the camera."""
-        rect = self.proxy.get_roi()
-        return rect[-2:]
+        roi = self.proxy.get_roi()  # left, bottom, right, top
+        binning = self.proxy.get_binning()
+        return (roi.width//binning.h, roi.height//binning.v)
 
 
     def getImageSizes(self, name):

--- a/cockpit/gui/imageViewer/viewCanvas.py
+++ b/cockpit/gui/imageViewer/viewCanvas.py
@@ -263,11 +263,14 @@ class Image(BaseGL):
             self._createTextures()
         shader = self.getShader()
         glUseProgram(shader)
+        # Vertical and horizontal modifiers for non-square images.
+        hlim = self._data.shape[1] / max(self._data.shape)
+        vlim = self._data.shape[0] / max(self._data.shape)
+        # Number of x and y textures.
         nx, ny = self.shape
-        dx = 2 / nx
-        dy = 2 / ny
-        xcorr = ycorr = 0
-        zoomcorr = 1
+        # Quad dimensions for one texture.
+        dx = 2 * hlim / nx
+        dy = 2 * vlim / ny
         if len(self._textures) > 1:
             tx = ty = self._maxTexEdge
             # xy & zoom correction for incompletely-filled textures at upper & right edges.
@@ -301,10 +304,10 @@ class Image(BaseGL):
                     ii = self._data.shape[1] / self._maxTexEdge
                 else:
                     ii = i+1
-                glVertexPointerf( [(-1 + i*dx, -1 + j*dy),
-                                   (-1 + ii*dx, -1 + j*dy),
-                                   (-1 + ii*dx, -1 + jj*dy),
-                                   (-1 + i*dx, -1 + jj*dy)] )
+                glVertexPointerf( [(-hlim + i*dx, -vlim + j*dy),
+                                   (-hlim + ii*dx, -vlim + j*dy),
+                                   (-hlim + ii*dx, -vlim + jj*dy),
+                                   (-hlim + i*dx, -vlim + jj*dy)] )
                 glTexCoordPointer(2, GL_FLOAT, 0,
                                   [(0, 0), (ii%1 or 1, 0), (ii%1 or 1, jj%1 or 1), (0, jj%1 or 1)])
                 glBindTexture(GL_TEXTURE_2D, self._textures[j*nx + i])

--- a/cockpit/gui/imageViewer/viewCanvas.py
+++ b/cockpit/gui/imageViewer/viewCanvas.py
@@ -304,10 +304,13 @@ class Image(BaseGL):
                     ii = self._data.shape[1] / self._maxTexEdge
                 else:
                     ii = i+1
-                glVertexPointerf( [(-hlim + i*dx, -vlim + j*dy),
-                                   (-hlim + ii*dx, -vlim + j*dy),
+                # Arrays used to create textures have top left at [0,0].
+                # GL co-ords run *bottom* left to top right, so need to invert
+                # vertical co-ords.
+                glVertexPointerf( [(-hlim + i*dx, -vlim + jj*dy),
                                    (-hlim + ii*dx, -vlim + jj*dy),
-                                   (-hlim + i*dx, -vlim + jj*dy)] )
+                                   (-hlim + ii*dx, -vlim + j*dy),
+                                   (-hlim + i*dx, -vlim + j*dy)] )
                 glTexCoordPointer(2, GL_FLOAT, 0,
                                   [(0, 0), (ii%1 or 1, 0), (ii%1 or 1, jj%1 or 1), (0, jj%1 or 1)])
                 glBindTexture(GL_TEXTURE_2D, self._textures[j*nx + i])

--- a/cockpit/gui/mosaic/canvas.py
+++ b/cockpit/gui/mosaic/canvas.py
@@ -156,10 +156,13 @@ class MosaicCanvas(wx.glcanvas.GLCanvas):
         # but this should require only up to three times the tilesize added to
         # the upper limit, not four.
         # Four works, though.
-        xMin += min(0, xOffLim[0])
+        # Arrays run [0,0] .. [ncols, nrows]; GL runs (-1,-1) .. (1,1). Since
+        # making adjustments to render [0,0] at (-1,1), we now add two megatiles
+        # at each y limit, rather than 4 at one edge.
+        xMin += min(0, xOffLim[0]) - tile.megaTileMicronSize
         xMax += max(0, xOffLim[1]) + tile.megaTileMicronSize
-        yMin += min(0, yOffLim[0])
-        yMax += max(0, yOffLim[1]) + 4 * tile.megaTileMicronSize
+        yMin += min(0, yOffLim[0]) - 2*tile.megaTileMicronSize
+        yMax += max(0, yOffLim[1]) + 2*tile.megaTileMicronSize
         for x in range(xMin, xMax, tile.megaTileMicronSize):
             for y in range(yMin, yMax, tile.megaTileMicronSize):
                 self.megaTiles.append(tile.MegaTile((-x, y)))

--- a/cockpit/gui/mosaic/tile.py
+++ b/cockpit/gui/mosaic/tile.py
@@ -232,13 +232,13 @@ class Tile:
 
         glBindTexture(GL_TEXTURE_2D, self.texture)
         glBegin(GL_QUADS)
-        glTexCoord2f(0, 0)
-        glVertex2f(x, y)        
-        glTexCoord2f(picTexRatio_x, 0)
-        glVertex2f(x + self.size[0], y)
-        glTexCoord2f(picTexRatio_x, picTexRatio_y)
-        glVertex2f(x + self.size[0], y + self.size[1])
         glTexCoord2f(0, picTexRatio_y)
+        glVertex2f(x, y)
+        glTexCoord2f(picTexRatio_x, picTexRatio_y)
+        glVertex2f(x + self.size[0], y)
+        glTexCoord2f(picTexRatio_x, 0)
+        glVertex2f(x + self.size[0], y + self.size[1])
+        glTexCoord2f(0, 0)
         glVertex2f(x, y + self.size[1])
         glEnd()
 
@@ -346,7 +346,7 @@ class MegaTile(Tile):
             glMatrixMode(GL_PROJECTION)
             glLoadIdentity()
             glOrtho(0, megaTilePixelSize * megaTileScaleFactor,
-                    0, megaTilePixelSize * megaTileScaleFactor,
+                    megaTilePixelSize * megaTileScaleFactor, 0,
                     1, 0)
             glTranslatef(-self.pos[0], -self.pos[1], 0)
             glMatrixMode(GL_MODELVIEW)


### PR DESCRIPTION
Fixed quad vertices for rendering in image viewer
Fixed GL coordinates throughout so that we render arrays with the same orientation as matplotlib.pyplot.imshow.