### PR TITLE
Mosaic large stages

### DIFF
--- a/cockpit/devices/camera.py
+++ b/cockpit/devices/camera.py
@@ -58,7 +58,7 @@ from . import device
 def Transform(tstr=None):
     """Desribes a simple transform: (flip LR, flip UD, rotate 90)"""
     if tstr:
-        return tuple([bool(t) for t in tstr.strip('()').split(',')])
+        return tuple([bool(int(t)) for t in tstr.strip('()').split(',')])
     else:
         return (False, False, False)
 

--- a/cockpit/devices/microscopeCamera.py
+++ b/cockpit/devices/microscopeCamera.py
@@ -244,8 +244,9 @@ class MicroscopeCamera(MicroscopeBase, camera.CameraDevice):
 
     def getImageSize(self, name):
         """Read the image size from the camera."""
-        rect = self.proxy.get_roi()
-        return rect[-2:]
+        roi = self.proxy.get_roi()  # left, bottom, right, top
+        binning = self.proxy.get_binning()
+        return (roi.width//binning.h, roi.height//binning.v)
 
 
     def getImageSizes(self, name):

--- a/cockpit/gui/imageViewer/viewCanvas.py
+++ b/cockpit/gui/imageViewer/viewCanvas.py
@@ -263,11 +263,14 @@ class Image(BaseGL):
             self._createTextures()
         shader = self.getShader()
         glUseProgram(shader)
+        # Vertical and horizontal modifiers for non-square images.
+        hlim = self._data.shape[1] / max(self._data.shape)
+        vlim = self._data.shape[0] / max(self._data.shape)
+        # Number of x and y textures.
         nx, ny = self.shape
-        dx = 2 / nx
-        dy = 2 / ny
-        xcorr = ycorr = 0
-        zoomcorr = 1
+        # Quad dimensions for one texture.
+        dx = 2 * hlim / nx
+        dy = 2 * vlim / ny
         if len(self._textures) > 1:
             tx = ty = self._maxTexEdge
             # xy & zoom correction for incompletely-filled textures at upper & right edges.
@@ -301,10 +304,10 @@ class Image(BaseGL):
                     ii = self._data.shape[1] / self._maxTexEdge
                 else:
                     ii = i+1
-                glVertexPointerf( [(-1 + i*dx, -1 + j*dy),
-                                   (-1 + ii*dx, -1 + j*dy),
-                                   (-1 + ii*dx, -1 + jj*dy),
-                                   (-1 + i*dx, -1 + jj*dy)] )
+                glVertexPointerf( [(-hlim + i*dx, -vlim + j*dy),
+                                   (-hlim + ii*dx, -vlim + j*dy),
+                                   (-hlim + ii*dx, -vlim + jj*dy),
+                                   (-hlim + i*dx, -vlim + jj*dy)] )
                 glTexCoordPointer(2, GL_FLOAT, 0,
                                   [(0, 0), (ii%1 or 1, 0), (ii%1 or 1, jj%1 or 1), (0, jj%1 or 1)])
                 glBindTexture(GL_TEXTURE_2D, self._textures[j*nx + i])

--- a/cockpit/gui/imageViewer/viewCanvas.py
+++ b/cockpit/gui/imageViewer/viewCanvas.py
@@ -304,10 +304,13 @@ class Image(BaseGL):
                     ii = self._data.shape[1] / self._maxTexEdge
                 else:
                     ii = i+1
-                glVertexPointerf( [(-hlim + i*dx, -vlim + j*dy),
-                                   (-hlim + ii*dx, -vlim + j*dy),
+                # Arrays used to create textures have top left at [0,0].
+                # GL co-ords run *bottom* left to top right, so need to invert
+                # vertical co-ords.
+                glVertexPointerf( [(-hlim + i*dx, -vlim + jj*dy),
                                    (-hlim + ii*dx, -vlim + jj*dy),
-                                   (-hlim + i*dx, -vlim + jj*dy)] )
+                                   (-hlim + ii*dx, -vlim + j*dy),
+                                   (-hlim + i*dx, -vlim + j*dy)] )
                 glTexCoordPointer(2, GL_FLOAT, 0,
                                   [(0, 0), (ii%1 or 1, 0), (ii%1 or 1, jj%1 or 1), (0, jj%1 or 1)])
                 glBindTexture(GL_TEXTURE_2D, self._textures[j*nx + i])

--- a/cockpit/gui/mosaic/canvas.py
+++ b/cockpit/gui/mosaic/canvas.py
@@ -54,13 +54,12 @@
 
 import numpy
 from OpenGL.GL import *
-import time
 import traceback
 import wx.glcanvas
 
 from cockpit import depot
 from cockpit import events
-from . import tile
+from .tile import Tile, MegaTile
 import cockpit.util.datadoc
 import cockpit.util.logger
 import cockpit.util.threads
@@ -159,13 +158,14 @@ class MosaicCanvas(wx.glcanvas.GLCanvas):
         # Arrays run [0,0] .. [ncols, nrows]; GL runs (-1,-1) .. (1,1). Since
         # making adjustments to render [0,0] at (-1,1), we now add two megatiles
         # at each y limit, rather than 4 at one edge.
-        xMin += min(0, xOffLim[0]) - tile.megaTileMicronSize
-        xMax += max(0, xOffLim[1]) + tile.megaTileMicronSize
-        yMin += min(0, yOffLim[0]) - 2*tile.megaTileMicronSize
-        yMax += max(0, yOffLim[1]) + 2*tile.megaTileMicronSize
-        for x in range(xMin, xMax, tile.megaTileMicronSize):
-            for y in range(yMin, yMax, tile.megaTileMicronSize):
-                self.megaTiles.append(tile.MegaTile((-x, y)))
+        MegaTile.setPixelSize(glGetInteger(GL_MAX_TEXTURE_SIZE))
+        xMin += min(0, xOffLim[0]) - MegaTile.micronSize
+        xMax += max(0, xOffLim[1]) + MegaTile.micronSize
+        yMin += min(0, yOffLim[0]) - 2*MegaTile.micronSize
+        yMax += max(0, yOffLim[1]) + 2*MegaTile.micronSize
+        for x in range(xMin, xMax, MegaTile.micronSize):
+            for y in range(yMin, yMax, MegaTile.micronSize):
+                self.megaTiles.append(MegaTile((-x, y)))
         self.haveInitedGL = True
 
 
@@ -294,7 +294,7 @@ class MosaicCanvas(wx.glcanvas.GLCanvas):
         self.SetCurrent(self.context)
         while not self.pendingImages.empty() and (time.time()-t < 0.05):
             data, pos, size, scalings, layer = self.pendingImages.get()
-            newTiles.append(tile.Tile(data, pos, size, scalings, layer))
+            newTiles.append(Tile(data, pos, size, scalings, layer))
         self.tiles.extend(newTiles)
         for megaTile in self.megaTiles:
             megaTile.prerenderTiles(newTiles, self)

--- a/cockpit/gui/mosaic/canvas.py
+++ b/cockpit/gui/mosaic/canvas.py
@@ -158,7 +158,16 @@ class MosaicCanvas(wx.glcanvas.GLCanvas):
         # Arrays run [0,0] .. [ncols, nrows]; GL runs (-1,-1) .. (1,1). Since
         # making adjustments to render [0,0] at (-1,1), we now add two megatiles
         # at each y limit, rather than 4 at one edge.
-        MegaTile.setPixelSize(glGetInteger(GL_MAX_TEXTURE_SIZE))
+        vendor = glGetString(GL_VENDOR)
+        tsize = glGetInteger(GL_MAX_TEXTURE_SIZE)
+        if vendor.startswith(b'Intel'):
+            # If we use the full texture size, it seems it's too large
+            # for manipulation in a framebuffer on Macs with Intel chipsets.
+            # GL_MAX_FRAMEBUFFER_WIDTH and _HEIGHT are not available, so we
+            # just use a quarter of the max texture size, which has been found
+            # to work intests on 2017-ish MacbookPro.
+            tsize //= 4
+        MegaTile.setPixelSize(tsize)
         xMin += min(0, xOffLim[0]) - MegaTile.micronSize
         xMax += max(0, xOffLim[1]) + MegaTile.micronSize
         yMin += min(0, yOffLim[0]) - 2*MegaTile.micronSize

--- a/cockpit/gui/mosaic/canvas.py
+++ b/cockpit/gui/mosaic/canvas.py
@@ -156,10 +156,13 @@ class MosaicCanvas(wx.glcanvas.GLCanvas):
         # but this should require only up to three times the tilesize added to
         # the upper limit, not four.
         # Four works, though.
-        xMin += min(0, xOffLim[0])
+        # Arrays run [0,0] .. [ncols, nrows]; GL runs (-1,-1) .. (1,1). Since
+        # making adjustments to render [0,0] at (-1,1), we now add two megatiles
+        # at each y limit, rather than 4 at one edge.
+        xMin += min(0, xOffLim[0]) - tile.megaTileMicronSize
         xMax += max(0, xOffLim[1]) + tile.megaTileMicronSize
-        yMin += min(0, yOffLim[0])
-        yMax += max(0, yOffLim[1]) + 4 * tile.megaTileMicronSize
+        yMin += min(0, yOffLim[0]) - 2*tile.megaTileMicronSize
+        yMax += max(0, yOffLim[1]) + 2*tile.megaTileMicronSize
         for x in range(xMin, xMax, tile.megaTileMicronSize):
             for y in range(yMin, yMax, tile.megaTileMicronSize):
                 self.megaTiles.append(tile.MegaTile((-x, y)))

--- a/cockpit/gui/mosaic/tile.py
+++ b/cockpit/gui/mosaic/tile.py
@@ -266,17 +266,6 @@ class Tile:
         return (self.size[0] / self.textureData.shape[0], 
                 self.size[1] / self.textureData.shape[1])
 
-
-
-## Length in pixels of one edge of a MegaTile's texture.
-megaTilePixelSize = 512
-## Length in microns of one edge of a MegaTile's texture.
-megaTileMicronSize = 500
-## Scaling factor to apply when prerendering to a MegaTile, so that
-# pixels line up properly at both render levels.
-megaTileScaleFactor = megaTileMicronSize / float(megaTilePixelSize)
-## Global numpy array of ones, used to initialize the MegaTile textures.
-megaTileData = numpy.ones((megaTilePixelSize, megaTilePixelSize), dtype = numpy.float32)
 ## Framebuffer to use when prerendering. Set to None initially since
 # we have to wait for OpenGL to get set up in our window before we can
 # use it.
@@ -292,6 +281,13 @@ def clearFramebuffer():
 # at a reduced level of detail, which allows us to keep the program
 # responsive even when thousands of tiles are in view.
 class MegaTile(Tile):
+    ## Length in pixels of one edge of a MegaTile's texture.
+    pixelSize = None
+    ## Length in microns of one edge of a MegaTile's texture.
+    micronSize = None
+    ## An array of ones, used to initialize the MegaTile textures.
+    _emptyTileData = None
+
     ## Instantiate the megatile. The main difference here is that
     # megatiles don't allocated any video memory until they have
     # something to display; since the majority of the mosaic is
@@ -300,8 +296,8 @@ class MegaTile(Tile):
     # At this time, if megaTileFramebuffer has not been created
     # yet, create it.
     def __init__(self, pos):
-        Tile.__init__(self, megaTileData, pos,
-                 (megaTileMicronSize, megaTileMicronSize),
+        Tile.__init__(self, self._emptyTileData, pos,
+                 (self.micronSize, self.micronSize),
                  (0, 1), 'megatiles',
                  shouldDelayAllocation = True)
         ## Counts the number of tiles we've rendered to ourselves.
@@ -313,6 +309,13 @@ class MegaTile(Tile):
         if megaTileFramebuffer is None:
             megaTileFramebuffer = glGenFramebuffers(1)
 
+    @classmethod
+    def setPixelSize(cls, edge):
+        if cls.pixelSize is not None:
+            raise Exception("MegaTile class already initialised.")
+        cls.pixelSize = edge
+        cls.micronSize = edge * 1
+        cls._emptyTileData = numpy.ones( (edge, edge), dtype=numpy.float32)
 
     ## Go through the provided list of Tiles, find the ones that overlap
     # our area, and prerender them to our texture
@@ -321,8 +324,8 @@ class MegaTile(Tile):
             return
         minX = self.pos[0]
         minY = self.pos[1]
-        maxX = self.pos[0] + megaTileMicronSize
-        maxY = self.pos[1] + megaTileMicronSize
+        maxX = self.pos[0] + self.micronSize
+        maxY = self.pos[1] + self.micronSize
         viewBox = ((minX, minY), (maxX, maxY))
         newTiles = []
         for tile in tiles:
@@ -342,12 +345,10 @@ class MegaTile(Tile):
             
             glPushMatrix()
             glLoadIdentity()
-            glViewport(0, 0, megaTilePixelSize, megaTilePixelSize)
+            glViewport(0, 0, self.pixelSize, self.pixelSize)
             glMatrixMode(GL_PROJECTION)
             glLoadIdentity()
-            glOrtho(0, megaTilePixelSize * megaTileScaleFactor,
-                    megaTilePixelSize * megaTileScaleFactor, 0,
-                    1, 0)
+            glOrtho(0, self.micronSize, self.micronSize, 0, 1, 0)
             glTranslatef(-self.pos[0], -self.pos[1], 0)
             glMatrixMode(GL_MODELVIEW)
 

--- a/cockpit/gui/mosaic/tile.py
+++ b/cockpit/gui/mosaic/tile.py
@@ -232,13 +232,13 @@ class Tile:
 
         glBindTexture(GL_TEXTURE_2D, self.texture)
         glBegin(GL_QUADS)
-        glTexCoord2f(0, 0)
-        glVertex2f(x, y)        
-        glTexCoord2f(picTexRatio_x, 0)
-        glVertex2f(x + self.size[0], y)
-        glTexCoord2f(picTexRatio_x, picTexRatio_y)
-        glVertex2f(x + self.size[0], y + self.size[1])
         glTexCoord2f(0, picTexRatio_y)
+        glVertex2f(x, y)
+        glTexCoord2f(picTexRatio_x, picTexRatio_y)
+        glVertex2f(x + self.size[0], y)
+        glTexCoord2f(picTexRatio_x, 0)
+        glVertex2f(x + self.size[0], y + self.size[1])
+        glTexCoord2f(0, 0)
         glVertex2f(x, y + self.size[1])
         glEnd()
 
@@ -346,7 +346,7 @@ class MegaTile(Tile):
             glMatrixMode(GL_PROJECTION)
             glLoadIdentity()
             glOrtho(0, megaTilePixelSize * megaTileScaleFactor,
-                    0, megaTilePixelSize * megaTileScaleFactor,
+                    megaTilePixelSize * megaTileScaleFactor, 0,
                     1, 0)
             glTranslatef(-self.pos[0], -self.pos[1], 0)
             glMatrixMode(GL_MODELVIEW)


### PR DESCRIPTION
*** One commit, to be applied after #499  ***

Improves mosaic performance for large stages.

    Mosaic was using 512x512 textures to represent 500um squares of stage
    space. For large stages, this meant a huge number of tiles. I now use the
    maximum texture size available, with a fixed ratio of 1 pixel per stage
    micron. This requires a bit of mucking about, as you can't query the
    maximum texture size until GL has been initialised.

    * Moved module-level globals onto the MegaTile class, set to None until
    they can be configured.
    * Mosaic canvas initilialises the MegaTile pixel size. This must only
    happen once, so MegaTile will raise an exception if anything tries to set
    it again.
    * Removed megaTileScaleFactor. This was only
    used to calculate megaTilePixelSize, which is a constant, anyway.
