### PR TITLE
Right click menu entry to save current image

### DIFF
--- a/cockpit/gui/camera/viewPanel.py
+++ b/cockpit/gui/camera/viewPanel.py
@@ -50,12 +50,7 @@
 ## ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 ## POSSIBILITY OF SUCH DAMAGE.
 
-
-import numpy
-import time
-import traceback
 import wx
-
 from cockpit import depot
 from cockpit import events
 import cockpit.util.threads
@@ -140,12 +135,6 @@ class ViewPanel(wx.Panel):
             item = menu.Append(-1, "Disable %s" % self.curCamera.descriptiveName)
             self.Bind(wx.EVT_MENU, lambda event: self.curCamera.toggleState(), item)
             menu.InsertSeparator(1)
-            items = self.canvas.getMenuActions()
-            for label, action in items:
-                item = menu.Append(-1, label)
-                self.Bind(wx.EVT_MENU,
-                        lambda event, action = action: action(), item)
-            menu.InsertSeparator(len(items) + 2)
             for size in self.curCamera.getImageSizes():
                 item = menu.Append(-1, "Set image size to %s" % str(size))
                 self.Bind(wx.EVT_MENU,
@@ -229,7 +218,6 @@ class ViewPanel(wx.Panel):
     ## Get the current pixel data for the view.
     def getPixelData(self):
         return self.canvas.imageData
-
 
     ## Debugging: convert to string.
     def __repr__(self):

--- a/cockpit/util/datadoc.py
+++ b/cockpit/util/datadoc.py
@@ -687,15 +687,14 @@ def writeMrcHeader(header, filehandle):
 # dimensions it will be augmented with dimensions of size 1 starting from
 # the left (e.g. a 512x512 array becomes a 1x1x1x512x512 array).
 def writeDataAsMrc(data, filename, XYSize = None, ZSize = None, wavelengths = []):
-    while len(data.shape) < 5:
-        # Fill in missing dimensions in the data.
-        data.shape = [1] + list(data.shape)
-    header = makeHeaderFor(data, XYSize = XYSize, ZSize = ZSize,
+    shape = (5 - len(data.shape)) * [1] + list(data.shape)
+    data_out = data.reshape(shape)
+    header = makeHeaderFor(data_out, XYSize = XYSize, ZSize = ZSize,
             wavelengths = wavelengths)
     handle = open(filename, 'wb')
     writeMrcHeader(header, handle)
     handle.seek(1024) # Seek to end of header
-    handle.write(data)
+    handle.write(data_out)
     handle.close()
 
 


### PR DESCRIPTION
If merged, makes #543 unnecessary.

* Makes writeDataAsMrc manipulate a copy of incoming data, rather than modifying its argument in place which may cause unintended side-effects.
* Makes viewCanvas context menu a persistent object so that it can use toggle items to indicate the state of toggled features.
* Adds an item to that context menu to save current image to an MRC file. It saves the original data, independent of the toggle-FFT state.