### PR TITLE
remove blank camera view unless there are no active views

### DIFF
--- a/cockpit/gui/camera/window.py
+++ b/cockpit/gui/camera/window.py
@@ -134,8 +134,10 @@ class CamerasWindow(wx.Frame):
             view.Show()
         for view in inactiveViews:
             self.sizer.Add(view)
-            if view is inactiveViews[0]:
-                view.Show()
+            #if there are no active views then display one empty panel
+            if not activeViews:
+                if view is inactiveViews[0]:
+                    view.Show()
                 # Other inactive views are hidden.
         self.sizer.Layout()
         self.panel.SetSizerAndFit(self.sizer)


### PR DESCRIPTION
This leaves a blank camera view if there are no active cameras. Otherwise only active cameras views will be active. Reduces wasted screen re-estate. 

Resolves issue #545