### PR TITLE
Hide log window

### DIFF
--- a/cockpit/__init__.py
+++ b/cockpit/__init__.py
@@ -115,9 +115,6 @@ class CockpitApp(wx.App):
                     maximum = numDevices + numNonDevices)
             status.Show()
 
-            # Do this early so we can see output while initializing.
-            cockpit.gui.loggingWindow.makeWindow(None)
-
             updateNum=1
             status.Update(updateNum, "Initializing config...")
             updateNum+=1
@@ -155,7 +152,8 @@ class CockpitApp(wx.App):
             # list.
             status.Update(updateNum, " ... secondary windows")
             updateNum+=1
-            for module_name in ['cockpit.gui.shellWindow',
+            for module_name in ['cockpit.gui.loggingWindow',
+                                'cockpit.gui.shellWindow',
                                 'cockpit.gui.touchscreen',
                                 'cockpit.util.intensity']:
                 module = importlib.import_module(module_name)

--- a/cockpit/gui/loggingWindow.py
+++ b/cockpit/gui/loggingWindow.py
@@ -67,7 +67,7 @@ import cockpit.util.logger
 class LoggingWindow(wx.Frame):
     def __init__(self, parent, title = 'Logging panels',
                  style = wx.CAPTION | wx.MAXIMIZE_BOX | wx.FRAME_NO_TASKBAR |
-                         wx.RESIZE_BORDER ):
+                         wx.RESIZE_BORDER |wx.CLOSE_BOX | wx.MINIMIZE_BOX):
         wx.Frame.__init__(self, parent, title = title, style = style)
 
         self.auiManager = wx.aui.AuiManager()
@@ -104,6 +104,9 @@ class LoggingWindow(wx.Frame):
     ## Send text to one of our output boxes, and also log that text.
     def write(self, target, *args):
         wx.CallAfter(target.AppendText, *args)
+        # text output reveles logging window
+        self.Show()
+                        
         with self.cacheLock:
             self.textCache += ' '.join(map(str, args))
             if '\n' in self.textCache:


### PR DESCRIPTION
Here is my suggested edits to open the logging window as a secondary window.

1) Adds minimise and close box to logging window, and auto opens it on error.

2) opens it later in the startup. Don't know how much of an issue this is. Adding it to secondary windows but opening it earlier seemed to require some gymnastics. 