### PR TITLE
MacroStageXY improvements

### DIFF
--- a/cockpit/gui/macroStage/macroStageBase.py
+++ b/cockpit/gui/macroStage/macroStageBase.py
@@ -250,13 +250,27 @@ class MacroStageBase(wx.glcanvas.GLCanvas):
     def drawTextAt(self, loc, text, size, color = (0, 0, 0)):
         width, height = self.GetClientSize()
         aspect = float(height) / width
+        if aspect >= 1.0:
+            # tall
+            scale_w = 1.0
+            scale_h = 1.0 / aspect
+        else:
+            # wide
+            scale_w = 1.0 * aspect
+            scale_h = 1.0
+        glMatrixMode(GL_PROJECTION)
+        glPushMatrix()
+        glLoadIdentity()
+        glMatrixMode(GL_MODELVIEW)
         glPushMatrix()
         glLoadIdentity()
         loc = self.scaledVertex(loc[0], loc[1], True)
         glTranslatef(loc[0], loc[1], 0)
-        glScalef(size * aspect, size, size)
+        glScalef(size * scale_w, size * scale_h, 1.0)
         glColor3fv(color)
         self.font.render(text)
+        glPopMatrix()
+        glMatrixMode(GL_PROJECTION)
         glPopMatrix()
 
 

--- a/cockpit/gui/macroStage/macroStageBase.py
+++ b/cockpit/gui/macroStage/macroStageBase.py
@@ -92,7 +92,9 @@ class MacroStageBase(wx.glcanvas.GLCanvas):
     ## Create the MacroStage. Mostly, attach a timer to the main window so
     # that we can use it to trigger updates.
     def __init__(self, parent, size, id = -1, *args, **kwargs):
-        wx.glcanvas.GLCanvas.__init__(self, parent, id, size = size, *args, **kwargs)
+        wx.glcanvas.GLCanvas.__init__(
+            self, parent, id, size = size, *args, **kwargs
+        )
 
         ## WX context for drawing.
         self.context = wx.glcanvas.GLContext(self)
@@ -142,12 +144,16 @@ class MacroStageBase(wx.glcanvas.GLCanvas):
         self.shouldForceRedraw = False
 
         ## Thread that ensures we don't spam redisplaying ourselves.
-        self.redrawTimerThread = threading.Thread(target=self.refreshWaiter, name="macrostage-refresh")
+        self.redrawTimerThread = threading.Thread(
+            target=self.refreshWaiter,
+            name="macrostage-refresh"
+        )
         self.redrawTimerThread.start()
 
         self.Bind(wx.EVT_PAINT, self.onPaint)
         self.Bind(wx.EVT_SIZE, lambda event: event)
-        self.Bind(wx.EVT_ERASE_BACKGROUND, lambda event: event) # Do nothing, to avoid flashing
+        # Do nothing in the erase background event, to avoid flashing
+        self.Bind(wx.EVT_ERASE_BACKGROUND, lambda event: event)
         events.subscribe(events.STAGE_POSITION, self.onMotion)
         events.subscribe("stage step size", self.onStepSizeChange)
         events.subscribe("stage step index", self.onStepIndexChange)
@@ -226,8 +232,14 @@ class MacroStageBase(wx.glcanvas.GLCanvas):
         angle = numpy.arctan2(delta[1], delta[0])
 
         pointLoc = baseLoc + delta
-        headLoc1 = pointLoc - numpy.array([numpy.cos(angle + ARROWHEAD_ANGLE), numpy.sin(angle + ARROWHEAD_ANGLE)]) * arrowHeadSize
-        headLoc2 = pointLoc - numpy.array([numpy.cos(angle - ARROWHEAD_ANGLE), numpy.sin(angle - ARROWHEAD_ANGLE)]) * arrowHeadSize
+        headLoc1 = pointLoc - numpy.array([
+            numpy.cos(angle + ARROWHEAD_ANGLE),
+            numpy.sin(angle + ARROWHEAD_ANGLE)
+        ]) * arrowHeadSize
+        headLoc2 = pointLoc - numpy.array([
+            numpy.cos(angle - ARROWHEAD_ANGLE),
+            numpy.sin(angle - ARROWHEAD_ANGLE)
+        ]) * arrowHeadSize
         
         # Draw
         glColor3f(color[0], color[1], color[2])
@@ -245,26 +257,36 @@ class MacroStageBase(wx.glcanvas.GLCanvas):
         glVertex2f(pointLoc[0], pointLoc[1])
         glEnd()
 
-    def drawTextAt(self, loc, text, scale_x=1.0, scale_y=1.0, alignment_h="left", alignment_v="bottom",
-                    colour=(0.0, 0.0, 0.0, 1.0), scale_axis_x=-1.0, scale_axis_y=1.0, draw_bbox=False):
+    def drawTextAt(self, loc, text, scale_x=1.0, scale_y=1.0,
+                   alignment_h="left", alignment_v="bottom",
+                   colour=(0.0, 0.0, 0.0, 1.0), scale_axis_x=-1.0,
+                   scale_axis_y=1.0, draw_bbox=False):
         """Draw a line of text.
 
-        Draw a line of text at the given location. Optionally, draw the bounding box as well.
-        Possible alignment arguments are:
+        Draw a line of text at the given location. Optionally, draw the
+        bounding box as well. Possible alignment arguments are:
             horizontal: left, baseline, centre, right
             vertical: top, middle, baseline, bottom
         The format of the colour argument is RGBA, range from 0 to 1.0.
 
         Args:
-            loc (tuple of int): The location, in OpenGL units, at which to draw the text.
+            loc (tuple of int): The location, in OpenGL units,
+                at which to draw the text.
             text (str): The text to be drawn.
-            scale_x (float): The scaling factor applied in the horizontal direction.
-            scale_y (float): The scaling factor applied in the vertical direction.
-            alignment_h (str): The horizontal alignment of the text with respect to the location.
-            alignment_v (str): The vertical alignment of the text with respect to the location.
-            colour (tuple of floats): The colour used for both the text and the bounding box.
-            scale_axis_x (float): The scaling factor of the x axis. Expect only -1.0 or 1.0.
-            scale_axis_y (float): The scaling factor of the y axis. Expect only -1.0 or 1.0.
+            scale_x (float): The scaling factor applied in the horizontal
+                direction.
+            scale_y (float): The scaling factor applied in the vertical
+                direction.
+            alignment_h (str): The horizontal alignment of the text with
+                respect to the location.
+            alignment_v (str): The vertical alignment of the text with
+                respect to the location.
+            colour (tuple of floats): The colour used for both the text and
+                the bounding box.
+            scale_axis_x (float): The scaling factor of the x axis.
+                Expect only -1.0 or 1.0.
+            scale_axis_y (float): The scaling factor of the y axis.
+                Expect only -1.0 or 1.0.
             draw_bbox (boolean): Whether to draw the bounding box of the text.
 
         """
@@ -297,7 +319,11 @@ class MacroStageBase(wx.glcanvas.GLCanvas):
         glMatrixMode(GL_MODELVIEW)
         glPushMatrix()
         glLoadIdentity()
-        glTranslatef(loc[0] + alignment_h_offset * scale_x, loc[1] + alignment_v_offset * scale_y, 0.0)
+        glTranslatef(
+            loc[0] + alignment_h_offset * scale_x,
+            loc[1] + alignment_v_offset * scale_y,
+            0.0
+        )
         glScalef(scale_x * scale_axis_x, scale_y * scale_axis_y, 1.0)
         # Render the text
         glColor4f(*colour)
@@ -314,57 +340,99 @@ class MacroStageBase(wx.glcanvas.GLCanvas):
         glPopMatrix()
         glMatrixMode(prev_mmode)
 
-    def drawStagePosition(self, label, drawLoc, positions, highlightIndex, stepSize, scale_max_x, scale_max_y,
-                           scale_axis_x=-1.0, scale_axis_y=1.0, alignment_h="left", alignment_v="top",
-                           hl_colour=(0.0, 0.5, 0.0, 1.0)):
+    def drawStagePosition(self, label, drawLoc, positions, highlightIndex,
+                          stepSize, scale_max_x, scale_max_y,
+                          scale_axis_x=-1.0, scale_axis_y=1.0,
+                          alignment_h="left", alignment_v="top",
+                          hl_colour=(0.0, 0.5, 0.0, 1.0)):
         """Draw a stage position line of text.
 
-        Draw a specially formatted line of text, describing the position of an entity such as an axis, as well as its
-        step size. If there is more than one not-None position, then are all drawn next to each other. The position
-        with index highlightIndex is coloured differently. The scaling factors are applied directly to the label,
-        whereas the rest of the text uses 0.75 of the same factors. Possible alignment arguments are:
+        Draw a specially formatted line of text, describing the position of an
+        entity such as an axis, as well as its step size. If there is more than
+        one not-None position, then are all drawn next to each other. The
+        position with index highlightIndex is coloured differently. The scaling
+        factors are applied directly to the label, whereas the rest of the text
+        uses 0.75 of the same factors. Possible alignment arguments are:
             horizontal: left, baseline, centre, right
             vertical: top, middle, baseline, bottom
         The format of the colour argument is RGBA, range from 0 to 1.0.
 
         Args:
-            label (str): The label of the entity, whose position and step size are being drawn.
-            drawLoc (tuple of int): The location, in OpenGL units, at which to draw the line of text.
-            positions (list of float): The entity positions. All None values are skipped.
+            label (str): The label of the entity, whose position and step size
+                are being drawn.
+            drawLoc (tuple of int): The location, in OpenGL units, at which to
+                draw the line of text.
+            positions (list of float): The entity positions. All None values
+                are skipped.
             highlightIndex (int): The index of the position to highlight.
             stepSize (float): The size of the entity's step.
-            scale_max_x (float): The scaling factor applied to the label in the horizontal direction.
-            scale_max_y (float): The scaling factor applied to the label in the vertical direction.
-            scale_axis_x (float): The scaling factor of the x axis. Expect only -1.0 or 1.0.
-            scale_axis_y (float): The scaling factor of the y axis. Expect only -1.0 or 1.0.
-            alignment_h (str): The horizontal alignment of the text with respect to the location.
-            alignment_v (str): The vertical alignment of the text with respect to the location.
-            hl_colour (tuple of floats): The colour used for highlighting one of the positions.
+            scale_max_x (float): The scaling factor applied to the label in the
+                horizontal direction.
+            scale_max_y (float): The scaling factor applied to the label in the
+                vertical direction.
+            scale_axis_x (float): The scaling factor of the x axis.
+                Expect only -1.0 or 1.0.
+            scale_axis_y (float): The scaling factor of the y axis.
+                Expect only -1.0 or 1.0.
+            alignment_h (str): The horizontal alignment of the text with
+                respect to the location.
+            alignment_v (str): The vertical alignment of the text with
+                respect to the location.
+            hl_colour (tuple of floats): The colour used for highlighting one
+                of the positions.
 
         """
         text_pos = list(drawLoc)
-        # Calculate the width of a space character
-        space_char_bbox = self.font.getFontBBox("  ")  # it's actually returning the bbox of a single space
-        space_char_width = (space_char_bbox[3] - space_char_bbox[0]) * scale_max_x
+        # Calculate the width of a space character. Even though two spaces are
+        # used, getFontBBox() actually returns the bbox of a single space
+        space_char_bbox = self.font.getFontBBox("  ")
+        space_char_width = (
+            (space_char_bbox[3] - space_char_bbox[0]) * scale_max_x
+        )
         # Pre-calculate the total width of all the text that will be drawn
         total_text_width = 0.0
         bbox_axis = self.font.getFontBBox(label)
-        total_text_width += ((bbox_axis[3] - bbox_axis[0]) * scale_max_x + space_char_width) * scale_axis_x
+        total_text_width += (
+            ((bbox_axis[3] - bbox_axis[0]) * scale_max_x + space_char_width) *
+            scale_axis_x
+        )
         bbox_miny = bbox_axis[1] * scale_max_y * scale_axis_y
         bbox_maxy = bbox_axis[4] * scale_max_y * scale_axis_y
         for pos in positions:
             if pos is None:
                 continue
             bbox_coord = self.font.getFontBBox("{:5.2f}".format(pos))
-            total_text_width += ((bbox_coord[3] - bbox_coord[0]) * scale_max_x * 0.75 + space_char_width) * scale_axis_x
-            bbox_miny = min(bbox_miny, bbox_coord[1] * scale_max_y * 0.75 * scale_axis_y)
-            bbox_maxy = max(bbox_maxy, bbox_coord[4] * scale_max_y * 0.75 * scale_axis_y)
+            total_text_width += (
+                    (
+                        (bbox_coord[3] - bbox_coord[0]) * scale_max_x * 0.75 +
+                        space_char_width
+                    ) *
+                    scale_axis_x
+            )
+            bbox_miny = min(
+                bbox_miny,
+                bbox_coord[1] * scale_max_y * 0.75 * scale_axis_y
+            )
+            bbox_maxy = max(
+                bbox_maxy,
+                bbox_coord[4] * scale_max_y * 0.75 * scale_axis_y
+            )
         total_text_width += (space_char_width * 3) * scale_axis_x
         bbox_step = self.font.getFontBBox("step: {:4.2f}um".format(stepSize))
-        total_text_width += ((bbox_step[3] - bbox_step[0]) * scale_max_x * 0.75) * scale_axis_x
-        bbox_miny = min(bbox_miny, bbox_step[1] * scale_max_y * 0.75 * scale_axis_y)
-        bbox_maxy = max(bbox_maxy, bbox_step[4] * scale_max_y * 0.75 * scale_axis_y)
-        # Calculate alignment offsets and apply them to the initial text position
+        total_text_width += (
+            ((bbox_step[3] - bbox_step[0]) * scale_max_x * 0.75) *
+            scale_axis_x
+        )
+        bbox_miny = min(
+            bbox_miny,
+            bbox_step[1] * scale_max_y * 0.75 * scale_axis_y
+        )
+        bbox_maxy = max(
+            bbox_maxy,
+            bbox_step[4] * scale_max_y * 0.75 * scale_axis_y
+        )
+        # Calculate alignment offsets and apply them to the initial text
+        # position
         alignment_offset_h = (0 - bbox_axis[0]) * scale_axis_x
         if alignment_h == "centre":
             alignment_offset_h = total_text_width / 2
@@ -382,8 +450,14 @@ class MacroStageBase(wx.glcanvas.GLCanvas):
             alignment_offset_v = bbox_miny
         text_pos[1] -= alignment_offset_v
         # Draw the axis label and advance the text position horizontal location
-        self.drawTextAt(text_pos, label, scale_max_x, scale_max_y, alignment_v="baseline", scale_axis_x=scale_axis_x)
-        text_pos[0] += ((bbox_axis[3] - bbox_axis[0]) * scale_max_x + space_char_width) * scale_axis_x
+        self.drawTextAt(
+            text_pos, label, scale_max_x, scale_max_y, alignment_v="baseline",
+            scale_axis_x=scale_axis_x
+        )
+        text_pos[0] += (
+            ((bbox_axis[3] - bbox_axis[0]) * scale_max_x + space_char_width) *
+            scale_axis_x
+        )
         for i, pos in enumerate(positions):
             if pos is None:
                 # No positioning for this axis.
@@ -401,7 +475,13 @@ class MacroStageBase(wx.glcanvas.GLCanvas):
                 scale_axis_x=scale_axis_x,
                 **colour_args
             )
-            text_pos[0] += ((bbox_coord[3] - bbox_coord[0]) * scale_max_x * 0.75 + space_char_width) * scale_axis_x
+            text_pos[0] += (
+                (
+                    (bbox_coord[3] - bbox_coord[0]) * scale_max_x * 0.75 +
+                    space_char_width
+                ) *
+                scale_axis_x
+            )
         # Add more horizontal spacings before the step size text
         text_pos[0] += (space_char_width * 3) * scale_axis_x
         # Draw the step size

--- a/cockpit/gui/macroStage/macroStageXY.py
+++ b/cockpit/gui/macroStage/macroStageXY.py
@@ -125,15 +125,15 @@ class MacroStageXY(macroStageBase.MacroStageBase):
 
         # Calculate soft stage limit label metrics and ensure there is enough space to draw them
         self.softlimit_label_scale = 0.0018 * combinedStageExtent
-        self.softlimit_label_line_height = ((self.font.getFontAscender() - self.font.getFontDescender()) *
+        softlimit_label_line_height = ((self.font.getFontAscender() - self.font.getFontDescender()) *
                                             self.softlimit_label_scale)
-        self.softlimit_label_offset = self.softlimit_label_line_height * 0.25
-        self.maxY += self.softlimit_label_offset + self.softlimit_label_line_height
-        self.minY -= self.softlimit_label_offset + self.softlimit_label_line_height
+        self.softlimit_label_offset = softlimit_label_line_height * 0.25
+        self.maxY += self.softlimit_label_offset + softlimit_label_line_height
+        self.minY -= self.softlimit_label_offset + softlimit_label_line_height
 
         # Calculate scale bar metrics and ensure there is enough space to draw it
-        self.scalebar_width_major = self.softlimit_label_line_height
-        self.scalebar_width_minor = self.softlimit_label_line_height * 0.5
+        self.scalebar_width_major = softlimit_label_line_height
+        self.scalebar_width_minor = softlimit_label_line_height * 0.5
         self.scalebar_position = self.minY - (self.scalebar_width_major / 2)  # vertical middle of scale bar
         self.minY = self.scalebar_position - (self.scalebar_width_major / 2)  # vertical bottom of scale bar
 
@@ -149,11 +149,11 @@ class MacroStageXY(macroStageBase.MacroStageBase):
         # Add margins for aesthetics and to ensure that all lines are entirely within the view area
         # NOTE: the margins may not be uniform
         minSideLength = min(self.maxX - self.minX, self.maxY - self.minY)
-        self.margin = 0.05 * minSideLength
-        self.minX -= self.margin
-        self.maxX += self.margin
-        self.minY -= self.margin
-        self.maxY += self.margin
+        margin = 0.05 * minSideLength
+        self.minX -= margin
+        self.maxX += margin
+        self.minY -= margin
+        self.maxY += margin
 
         # Correct the view area to preserve the aspect ratio of the stage
         aratio_viewport = width / height

--- a/cockpit/gui/macroStage/macroStageXY.py
+++ b/cockpit/gui/macroStage/macroStageXY.py
@@ -98,8 +98,8 @@ class MacroStageXY(macroStageBase.MacroStageBase):
         events.subscribe("soft safety limit", self.onSafetyChange)
         events.subscribe('objective change', self.onObjectiveChange)
         self.SetToolTip(wx.ToolTip("Left double-click to move the stage. " +
-                "Right click for gotoXYZ and double-click to toggle displaying of mosaic " +
-                "tiles."))
+                "Right click for gotoXYZ and double-click to toggle" +
+                "displayingof mosaic tiles."))
 
     ## Dynamically calculate various parameters used for the drawing and modify
     ## the viewing area accordingly
@@ -108,13 +108,17 @@ class MacroStageXY(macroStageBase.MacroStageBase):
         # which has micrometers as units
         width, height = self.GetClientSize()
         hardLimits = cockpit.interfaces.stageMover.getHardLimits()
-        combinedStageExtent = (hardLimits[0][1] - hardLimits[0][0]) + (hardLimits[1][1] - hardLimits[1][0])
+        combinedStageExtent = (
+                (hardLimits[0][1] - hardLimits[0][0]) +
+                (hardLimits[1][1] - hardLimits[1][0])
+        )
 
         # Calculate the largest objective offsets
         _maxOffsetX = max([abs(offsets[0]) for offsets in self.listOffsets])
         _maxOffsetY = max([abs(offsets[1]) for offsets in self.listOffsets])
 
-        # Initialise the view area to the area of the stage's hard limits, accounting for largest objective offsets
+        # Initialise the view area to the area of the stage's hard limits,
+        # accounting for largest objective offsets
         self.minX, self.maxX = hardLimits[0]
         self.minY, self.maxY = hardLimits[1]
         self.minX -= _maxOffsetX
@@ -122,30 +126,41 @@ class MacroStageXY(macroStageBase.MacroStageBase):
         self.minY -= _maxOffsetY
         self.maxY += _maxOffsetY
 
-        # Calculate soft stage limit label metrics and ensure there is enough space to draw them
+        # Calculate soft stage limit label metrics and ensure that
+        # there is enough space to draw them
         softlimit_label_scale = 0.0018 * combinedStageExtent
-        softlimit_label_line_height = ((self.font.getFontAscender() - self.font.getFontDescender()) *
-                                            softlimit_label_scale)
+        softlimit_label_line_height = (
+            (self.font.getFontAscender() - self.font.getFontDescender()) *
+            softlimit_label_scale
+        )
         softlimit_label_offset = softlimit_label_line_height * 0.25
         self.maxY += softlimit_label_offset + softlimit_label_line_height
         self.minY -= softlimit_label_offset + softlimit_label_line_height
 
-        # Calculate scale bar metrics and ensure there is enough space to draw it
+        # Calculate scale bar metrics and ensure that
+        # there is enough space to draw it
         scalebar_height_major = softlimit_label_line_height
         scalebar_height_minor = softlimit_label_line_height * 0.5
-        scalebar_position_v = self.minY - (scalebar_height_major / 2)  # vertical middle of scale bar
-        self.minY = scalebar_position_v - (scalebar_height_major / 2)  # vertical bottom of scale bar
+        scalebar_position_v = self.minY - (scalebar_height_major / 2)
+        self.minY = scalebar_position_v - (scalebar_height_major / 2)
 
-        # Ensure there is enough space to draw the coordinate and step size labels. The position is slightly offset,
-        # proportionally to the line height, in order to create a small gap from the top soft stage limit label.
+        # Ensure there is enough space to draw the coordinate and step size
+        # labels. The position is slightly offset, proportionally to the line
+        # height, in order to create a small gap from the top soft stage
+        # limit label.
         coord_labels_scale_max = 0.0025 * combinedStageExtent
-        coord_labels_line_height = ((self.font.getFontAscender() - self.font.getFontDescender()) *
-                                          coord_labels_scale_max)
-        coord_labels_position = (self.maxY + coord_labels_line_height * 0.25 +
-                                      2 * coord_labels_line_height)
+        coord_labels_line_height = (
+            (self.font.getFontAscender() - self.font.getFontDescender()) *
+            coord_labels_scale_max
+        )
+        coord_labels_position = (
+                self.maxY + coord_labels_line_height * 0.25 +
+                2 * coord_labels_line_height
+        )
         self.maxY = coord_labels_position
 
-        # Add margins for aesthetics and to ensure that all lines are entirely within the view area
+        # Add margins for aesthetics and to ensure that all lines are
+        # entirely within the view area
         # NOTE: the margins may not be uniform
         minSideLength = min(self.maxX - self.minX, self.maxY - self.minY)
         margin = 0.05 * minSideLength
@@ -158,13 +173,21 @@ class MacroStageXY(macroStageBase.MacroStageBase):
         aratio_viewport = width / height
         aratio_viewarea = (self.maxX - self.minX) / (self.maxY - self.minY)
         if aratio_viewport >= aratio_viewarea:
-            # The viewport is wider than the stage => expose more horizontal scene space
-            extra_space = ((aratio_viewport - aratio_viewarea) / aratio_viewarea) * (self.maxX - self.minX)
+            # The viewport is wider than the stage =>
+            # expose more horizontal scene space
+            extra_space = (
+              ((aratio_viewport - aratio_viewarea) / aratio_viewarea) *
+              (self.maxX - self.minX)
+            )
             self.minX -= extra_space / 2
             self.maxX += extra_space / 2
         else:
-            # The viewport is taller than the stage => expose more vertical scene space
-            extra_space = ((aratio_viewarea - aratio_viewport) / aratio_viewport) * (self.maxY - self.minY)
+            # The viewport is taller than the stage =>
+            # expose more vertical scene space
+            extra_space = (
+                ((aratio_viewarea - aratio_viewport) / aratio_viewport) *
+                (self.maxY - self.minY)
+            )
             self.minY -= extra_space / 2
             self.maxY += extra_space / 2
 
@@ -229,7 +252,10 @@ class MacroStageXY(macroStageBase.MacroStageBase):
             hardLimits = cockpit.interfaces.stageMover.getHardLimits()[:2]
             # Rearrange limits to (x, y) tuples.
             hardLimits = list(zip(hardLimits[0], hardLimits[1]))
-            maxStageExtent = max(hardLimits[1][0] - hardLimits[0][0], hardLimits[1][1] - hardLimits[0][1])
+            maxStageExtent = max(
+                hardLimits[1][0] - hardLimits[0][0],
+                hardLimits[1][1] - hardLimits[0][1]
+            )
 
             # Set up transform from stage to screen units
             glMatrixMode(GL_PROJECTION)
@@ -350,8 +376,10 @@ class MacroStageXY(macroStageBase.MacroStageBase):
             glColor3f(*colour)
             glBegin(GL_LINE_LOOP)
             for (x, y) in squareOffsets:
-                glVertex2f(motorPos[0] - offset[0] + squareSize * x - squareSize / 2,
-                           motorPos[1] + offset[1] + squareSize * y - squareSize / 2)
+                glVertex2f(
+                    motorPos[0] - offset[0] + squareSize * x - squareSize / 2,
+                    motorPos[1] + offset[1] + squareSize * y - squareSize / 2
+                )
             glEnd()
 
             # Draw motion crosshairs
@@ -363,8 +391,14 @@ class MacroStageXY(macroStageBase.MacroStageBase):
                     continue
                 hairLengths = [0, 0]
                 hairLengths[i] = stepSize
-                glVertex2f(motorPos[0] - offset[0] - hairLengths[0], motorPos[1] + offset[1] - hairLengths[1])
-                glVertex2f(motorPos[0] - offset[0] + hairLengths[0], motorPos[1] + offset[1] + hairLengths[1])
+                glVertex2f(
+                    motorPos[0] - offset[0] - hairLengths[0],
+                    motorPos[1] + offset[1] - hairLengths[1]
+                )
+                glVertex2f(
+                    motorPos[0] - offset[0] + hairLengths[0],
+                    motorPos[1] + offset[1] + hairLengths[1]
+                )
             glEnd()
 
             # Draw direction of motion
@@ -384,7 +418,11 @@ class MacroStageXY(macroStageBase.MacroStageBase):
             glVertex2f(hardLimits[0][0], dParams["sb"]["position_v"])
             glVertex2f(hardLimits[1][0], dParams["sb"]["position_v"])
             # Draw notches in the scale bar every 1mm.
-            for scaleX in range(int(hardLimits[0][0]), int(hardLimits[1][0]) + 1000, 1000):
+            for scaleX in range(
+                    int(hardLimits[0][0]),
+                    int(hardLimits[1][0]) + 1000,
+                    1000
+            ):
                 width = dParams["sb"]["tick_height_minor"]
                 if scaleX % 5000 == 0:
                     width = dParams["sb"]["tick_height_major"]
@@ -407,8 +445,14 @@ class MacroStageXY(macroStageBase.MacroStageBase):
                 self.drawStagePosition(
                     axis_label,
                     (
-                        hardLimits[0][0] + (hardLimits[1][0] - hardLimits[0][0]) / 2,
-                        dParams["cssl"]["position_v"] - index * dParams["cssl"]["line_height"]
+                        (
+                            hardLimits[0][0] +
+                            (hardLimits[1][0] - hardLimits[0][0]) / 2
+                        ),
+                        (
+                            dParams["cssl"]["position_v"] -
+                            index * dParams["cssl"]["line_height"]
+                        )
                     ),
                     positions,
                     curControl,
@@ -426,7 +470,10 @@ class MacroStageXY(macroStageBase.MacroStageBase):
             # our stage position info.
             self.drawEvent.set()
         except Exception as e:
-            cockpit.util.logger.log.error("Exception drawing XY macro stage: %s", e)
+            cockpit.util.logger.log.error(
+                "Exception drawing XY macro stage: %s",
+                e
+            )
             cockpit.util.logger.log.error(traceback.format_exc())
             self.shouldDraw = False
 
@@ -481,7 +528,9 @@ class MacroStageXY(macroStageBase.MacroStageBase):
         #distance with exisiting mover
         cockpit.interfaces.stageMover.mover.curHandlerIndex = 0
 
-        cockpit.interfaces.stageMover.goToXY(self.remapClick(event.GetPosition()))
+        cockpit.interfaces.stageMover.goToXY(
+            self.remapClick(event.GetPosition())
+        )
 
         #make sure we are back to the expected mover
         cockpit.interfaces.stageMover.mover.curHandlerIndex = originalMover
@@ -495,22 +544,41 @@ class MacroStageXY(macroStageBase.MacroStageBase):
                 atMouse=True)
         newPos=[float(values[0]),float(values[1]),float(values[2])]
 #Work out if we will be ouside the limits of the current stage
-        posDelta = [newPos[0]-position[0],newPos[1]-position[1],newPos[2]-position[2]]
-        originalHandlerIndex = cockpit.interfaces.stageMover.mover.curHandlerIndex
+        posDelta = [
+            newPos[0] - position[0],
+            newPos[1] - position[1],
+            newPos[2] - position[2]
+        ]
+        originalHandlerIndex = (
+            cockpit.interfaces.stageMover.mover.curHandlerIndex
+        )
         currentHandlerIndex = originalHandlerIndex
         allPositions=cockpit.interfaces.stageMover.getAllPositions()
         for axis in range(3):
             if (posDelta[axis]**2 > .001 ):
-                    limits = cockpit.interfaces.stageMover.getIndividualHardLimits(axis)
-                    currentpos = allPositions[currentHandlerIndex][axis]
-                    if ((currentpos + posDelta[axis]<(limits[currentHandlerIndex][0])) # off bottom
-                        or (currentpos + posDelta[axis]>(limits[currentHandlerIndex][1]))): #off top
-                        currentHandlerIndex -= 1 # go to a bigger handler index
-                    if currentHandlerIndex<0:
-                        return False
-        cockpit.interfaces.stageMover.mover.curHandlerIndex = currentHandlerIndex
+                limits = (
+                    cockpit.interfaces.stageMover.getIndividualHardLimits(axis)
+                )
+                currentpos = allPositions[currentHandlerIndex][axis]
+                off_bottom = (
+                    (currentpos + posDelta[axis]) <
+                    (limits[currentHandlerIndex][0])
+                )
+                off_top = (
+                    (currentpos + posDelta[axis]) >
+                    (limits[currentHandlerIndex][1])
+                )
+                if off_bottom or off_top:
+                    currentHandlerIndex -= 1 # go to a bigger handler index
+                if currentHandlerIndex<0:
+                    return False
+        cockpit.interfaces.stageMover.mover.curHandlerIndex = (
+            currentHandlerIndex
+        )
         cockpit.interfaces.stageMover.goTo(newPos)
-        cockpit.interfaces.stageMover.mover.curHandlerIndex = originalHandlerIndex
+        cockpit.interfaces.stageMover.mover.curHandlerIndex = (
+            originalHandlerIndex
+        )
         return True
 
 
@@ -522,8 +590,14 @@ class MacroStageXY(macroStageBase.MacroStageBase):
     ## Remap a click location from pixel coordinates to realspace coordinates
     def remapClick(self, clickLoc):
         width, height = self.GetClientSize()
-        x = float(width - clickLoc[0]) / width * (self.maxX - self.minX) + self.minX
-        y = float(height - clickLoc[1]) / height * (self.maxY - self.minY) + self.minY
+        x = (
+            float(width - clickLoc[0]) / width * (self.maxX - self.minX) +
+            self.minX
+        )
+        y = (
+            float(height - clickLoc[1]) / height * (self.maxY - self.minY) +
+            self.minY
+        )
         return [x+self.offset[0], y-self.offset[1]]
 
 

--- a/cockpit/gui/macroStage/macroStageXY.py
+++ b/cockpit/gui/macroStage/macroStageXY.py
@@ -177,17 +177,6 @@ class MacroStageXY(macroStageBase.MacroStageBase):
             wx.CallAfter(self.Refresh)
 
 
-    def projectionMatrix(self):
-        ## Transform from stage co-ordinates to normalized device coordinates (NDC)
-        dx = self.maxX - self.minX
-        dy = self.maxY - self.minY
-        # Column-major ordering
-        return   [-2/dx,  0,     0,   0,
-                  0,      2/dy,  0,   0,
-                  0,      0,     1,   0,
-                  2*self.minX/dx+1,  -2*self.minY/dy-1, 0, 1]
-
-
     ## Draw the canvas. We draw the following:
     # - A blue dotted square representing the hard stage limits of
     #   [(4000, 4000), (25000, 25000)]
@@ -227,7 +216,8 @@ class MacroStageXY(macroStageBase.MacroStageBase):
 
             # Set up transform from stage to screen units
             glMatrixMode(GL_PROJECTION)
-            glLoadMatrixf(self.projectionMatrix())
+            glLoadIdentity()
+            glOrtho(self.maxX, self.minX, self.minY, self.maxY, -1.0, 1.0)
 
             #Loop over objective offsets to draw limist in multiple colours.
             safeties = []

--- a/cockpit/gui/macroStage/macroStageXY.py
+++ b/cockpit/gui/macroStage/macroStageXY.py
@@ -314,7 +314,7 @@ class MacroStageXY(macroStageBase.MacroStageBase):
                     dParams["ssll"]["offset"]
                 )
                 for i, (x, y) in enumerate(softLimits):
-                    label = "({:d}, {:d})".format(x, y)
+                    label = "({:.02f}, {:.02f})".format(x, y)
                     self.drawTextAt(
                         (x, y + label_vertical_offsets[i]),
                         label,

--- a/cockpit/gui/macroStage/macroStageXY.py
+++ b/cockpit/gui/macroStage/macroStageXY.py
@@ -138,12 +138,13 @@ class MacroStageXY(macroStageBase.MacroStageBase):
         self.minY = self.scalebar_position - (self.scalebar_width_major / 2)  # vertical bottom of scale bar
 
         # Ensure there is enough space to draw the coordinate and step size labels. The position is slightly offset,
-        # proportionally to the line height, in order to create a small gap from the scale bar.
+        # proportionally to the line height, in order to create a small gap from the top soft stage limit label.
         self.coord_labels_scale_max = 0.0025 * combinedStageExtent
         self.coord_labels_line_height = ((self.font.getFontAscender() - self.font.getFontDescender()) *
                                           self.coord_labels_scale_max)
-        self.coord_labels_position = self.minY - self.coord_labels_line_height * 0.25
-        self.minY = self.coord_labels_position - 2 * self.coord_labels_line_height
+        self.coord_labels_position = (self.maxY + self.coord_labels_line_height * 0.25 +
+                                      2 * self.coord_labels_line_height)
+        self.maxY = self.coord_labels_position
 
         # Add margins for aesthetics and to ensure that all lines are entirely within the view area
         # NOTE: the margins may not be uniform

--- a/cockpit/gui/macroStage/macroStageZ.py
+++ b/cockpit/gui/macroStage/macroStageZ.py
@@ -459,14 +459,38 @@ class MacroStageZ(macroStageBase.MacroStageBase):
 
             # Draw histogram min/max
             if histogram.shouldLabel:
-                lineHeight = self.stageExtent * .05
-                self.drawTextAt((histogram.xOffset + self.stageExtent * .05, 
-                        minY - self.textLineHeight / 4),
-                        str(int(histogram.minAltitude)), size = self.textSize)
-                self.drawTextAt((histogram.xOffset + self.stageExtent * .05, 
-                        maxY - self.textLineHeight / 4),
-                        str(int(histogram.maxAltitude)), size = self.textSize)
-            
+                text_scale = 0.005
+                width, height = self.GetClientSize()
+                aspect = height / width
+                if aspect >= 1.0:
+                    # tall
+                    text_scale_x = text_scale
+                    text_scale_y = text_scale / aspect
+                else:
+                    # wide
+                    text_scale_x = text_scale * aspect
+                    text_scale_y = text_scale
+                self.drawTextAt(
+                    self.scaledVertex(
+                        histogram.xOffset + self.stageExtent * .05,
+                        minY - self.textLineHeight / 4,
+                        shouldReturn=True),
+                    str(int(histogram.minAltitude)),
+                    text_scale_x,
+                    text_scale_y,
+                    scale_axis_x=1.0
+                )
+                self.drawTextAt(
+                    self.scaledVertex(
+                        histogram.xOffset + self.stageExtent * .05,
+                        maxY - self.textLineHeight / 4,
+                        shouldReturn=True),
+                    str(int(histogram.maxAltitude)),
+                    text_scale_x,
+                    text_scale_y,
+                    scale_axis_x=1.0
+                )
+
             # Draw histogram stage motion delta
             stepSize = cockpit.interfaces.stageMover.getCurStepSizes()[2]
             if stepSize is not None:
@@ -535,20 +559,45 @@ class MacroStageZ(macroStageBase.MacroStageBase):
             labelX = rightEdge - self.stageExtent * .01
             if isLabelOnLeft:
                 labelX = leftEdge + self.stageExtent * .1
+            text_scale = 0.005
+            width, height = self.GetClientSize()
+            aspect = height / width
+            if aspect >= 1.0:
+                # tall
+                text_scale_x = text_scale
+                text_scale_y = text_scale / aspect
+            else:
+                # wide
+                text_scale_x = text_scale * aspect
+                text_scale_y = text_scale
             if shouldLabelMainView:
                 # Draw a text label next to the line, in the line's color.
                 self.drawTextAt(
-                        (labelX, drawAltitude - self.textLineHeight / 4), 
-                        label, size = self.textSize, color = color)
+                    self.scaledVertex(labelX, drawAltitude - self.textLineHeight / 4, shouldReturn=True),
+                    label,
+                    text_scale_x,
+                    text_scale_y,
+                    colour=(*color, 1.0),
+                    scale_axis_x=1.0
+                )
             if shouldLabelHistogram:
                 # Draw the label for the histograms too.
                 for histogram in self.histograms:
                     if histogram.shouldLabel:
                         histogramAltitude = histogram.scale(altitude)
                         histogramLabelX = labelX - histogram.xOffset + self.horizLineLength / 2
-                        self.drawTextAt((histogramLabelX,
-                                histogramAltitude - self.textLineHeight / 4),
-                                label, size = self.textSize, color = color)
+                        self.drawTextAt(
+                            self.scaledVertex(
+                                histogramLabelX,
+                                histogramAltitude - self.textLineHeight / 4,
+                                shouldReturn=True
+                            ),
+                            label,
+                            text_scale_x,
+                            text_scale_y,
+                            colour=(*color, 1.0),
+                            scale_axis_x=1.0
+                        )
 
 
     ## Double click moves the stage in Z.
@@ -630,13 +679,22 @@ class MacroStageZKey(macroStageBase.MacroStageBase):
             glLineWidth(1)
 
             # Draw textual position coordinates.
+            text_scale = 0.04
+            aspect = height / width
+            if aspect >= 1.0:
+                # tall
+                text_scale_x = text_scale
+                text_scale_y = text_scale / aspect
+            else:
+                # wide
+                text_scale_x = text_scale * aspect
+                text_scale_y = text_scale
             positions = cockpit.interfaces.stageMover.getAllPositions()
             positions = [p[2] for p in positions]
             stepSize = cockpit.interfaces.stageMover.getCurStepSizes()[2]
-            self.drawStagePosition('Z:', positions, 
-                    cockpit.interfaces.stageMover.getCurHandlerIndex(), stepSize, 
-                    (self.xOffset, self.yOffset), self.xExtent * .25, 
-                    self.xExtent * .05, self.textSize)
+            self.drawStagePosition("Z:", (0, 0), positions, cockpit.interfaces.stageMover.getCurHandlerIndex(),
+                                    stepSize, text_scale_x, text_scale_y, scale_axis_x=1.0, alignment_h="centre",
+                                    alignment_v="middle")
 
             glFlush()
             self.SwapBuffers()

--- a/cockpit/util/ftgl.py
+++ b/cockpit/util/ftgl.py
@@ -24,7 +24,7 @@ import ctypes
 import os
 import sys
 
-from ctypes import POINTER, c_char_p, c_int, c_uint
+from ctypes import POINTER, c_char_p, c_int, c_uint, c_float
 
 try:
     if os.name in ('nt', 'ce'):
@@ -79,6 +79,20 @@ _getFontError = _ftgl.ftglGetFontError
 _getFontError.argtypes = [POINTER(_FTGLfont)]
 _getFontError.restype = _FT_Error
 
+## void ftglGetFontBBox (FTGLfont *font, const char *string, int len, float bounds[6])
+_getFontBBox = _ftgl.ftglGetFontBBox
+_getFontBBox.argtypes = [POINTER(_FTGLfont), c_char_p, c_int, (c_float * 6)]
+_getFontBBox.restype = None
+
+## float ftglGetFontAscender (FTGLfont *font)
+_getFontAscender = _ftgl.ftglGetFontAscender
+_getFontAscender.argtypes = [POINTER(_FTGLfont)]
+_getFontAscender.restype = c_float
+
+## float ftglGetFontDescender (FTGLfont *font)
+_getFontDescender = _ftgl.ftglGetFontDescender
+_getFontDescender.argtypes = [POINTER(_FTGLfont)]
+_getFontDescender.restype = c_float
 
 class TextureFont(object):
     def __init__(self, path):
@@ -99,3 +113,14 @@ class TextureFont(object):
         err = _getFontError(self._font)
         if err != 0:
             raise RuntimeError("failed to render '%s'", text)
+
+    def getFontBBox(self, text, len=-1):
+        retval = (c_float * 6)()
+        _getFontBBox(self._font, text.encode('ascii'), len, retval)
+        return list(retval)
+
+    def getFontAscender(self):
+        return _getFontAscender(self._font)
+
+    def getFontDescender(self):
+        return _getFontDescender(self._font)


### PR DESCRIPTION
These are the changes necessary to make the MacroStageXY draw correctly regardless of the canvas size. While at it, I fixed the way the scalebar and cross hairs are drawn, as they seemed wrong. There also some other small bugfixes, like not drawing the corner labels if the soft limits coincide with the hard limits.

Addresses #585.

Here are before and after images, respectively:

![before](https://user-images.githubusercontent.com/56877735/80346972-8c95f880-8863-11ea-8a0e-f7ccd9c338d1.png)

![after](https://user-images.githubusercontent.com/56877735/80346980-90c21600-8863-11ea-887b-f9a270d0a219.png)
