### PR TITLE
Fix texture issues

### DIFF
--- a/cockpit/gui/freetype.py
+++ b/cockpit/gui/freetype.py
@@ -148,16 +148,6 @@ class _Glyph:
 
         glPopClientAttrib()
 
-    def release(self) -> None:
-        """Delete associated textures.
-
-        We need to use this instead of ``__del__`` because by the time
-        the finaliser is called the GLContext might already have been
-        destroyed.
-
-        """
-        del self
-
     @property
     def advance(self) -> numpy.ndarray:
         return self._advance
@@ -203,7 +193,6 @@ class Face:
     def _OnWindowDestroy(self, event: wx.WindowDestroyEvent) -> None:
         while self._glyphs:
             char_glyph = self._glyphs.popitem()
-            char_glyph[1].release()
         event.Skip()
 
     def render(self, text: str) -> None:

--- a/cockpit/gui/freetype.py
+++ b/cockpit/gui/freetype.py
@@ -156,7 +156,7 @@ class _Glyph:
         destroyed.
 
         """
-        glDeleteTextures([self._texture_id])
+        del self
 
     @property
     def advance(self) -> numpy.ndarray:


### PR DESCRIPTION
This is the call that is causing the issues with the mosaic, though I'm not clear about why.

From what I can tell, there's no need to use `glDeleteTextures` on window close as textures that are exclusive to a context are automatically deleted with the context anyway. I'm assuming the frequent (but inconsistent) mosaic issues are due to timing often causing duplicate calls to `glDeleteTextures`, causing some break in OpenGL. As the mosaic would be the next obvious OpenGL update, that's where I noticed an issue. That could also explain why it often worked better the first time I ran Cockpit after checking out a different commit, as the pycache wouldn't have been updated, slowing down the call.

Closes #787 