### PR TITLE
Fix single-site experiement dialog reset

### DIFF
--- a/cockpit/gui/dialogs/experiment/singleSiteExperiment.py
+++ b/cockpit/gui/dialogs/experiment/singleSiteExperiment.py
@@ -130,20 +130,15 @@ class SingleSiteExperimentDialog(wx.Dialog):
             self.Hide()
 
 
-    ## Blow away the experiment panel and recreate it from scratch.
-    def onReset(self, event = None):
-        self.sizer.Remove(self.panel)
-        self.panel.Destroy()
-        self.panel = experimentConfigPanel.ExperimentConfigPanel(self,
-                resizeCallback = self.onExperimentPanelResize,
-                resetCallback = self.onReset)
-        self.sizer.Prepend(self.panel)
-        self.sizer.Layout()
-        self.Refresh()
-        self.SetSizerAndFit(self.sizer)
-        return self.panel
-        
-        
+    ## Blow away the dialog and recreate it from scratch.
+    def onReset(self, event):
+        parent = self.GetParent()
+        global dialog
+        dialog.Destroy()
+        dialog = None
+        showDialog(parent)
+
+
 
 
 ## Global singleton


### PR DESCRIPTION
Use `onReset` from multi-site experiment dialog. Single-site experiment dialog was giving the following error:
```
Traceback (most recent call last):
  File "c:\b24\cockpit\cockpit\gui\dialogs\experiment\singleSiteExperiment.py", line 136, in onReset
    self.sizer.Remove(self.panel)
TypeError: Sizer.Remove(): arguments did not match any overloaded call:
  overload 1: argument 1 has unexpected type 'ExperimentConfigPanel'
  overload 2: argument 1 has unexpected type 'ExperimentConfigPanel'
```