### PR TITLE
Bring back the mosaic loading progress bar

### DIFF
--- a/cockpit/gui/mosaic/canvas.py
+++ b/cockpit/gui/mosaic/canvas.py
@@ -136,7 +136,9 @@ class MosaicCanvas(wx.glcanvas.GLCanvas):
         #event on DPI chnage on high DPI screens, needed for Mac retina
         #displays.
         self.Bind(wx.EVT_DPI_CHANGED, self.onDPIchange)
-  
+        self.Bind(EVT_PROGRESS_START, self.createProgressDialog)
+        self.Bind(EVT_PROGRESS_UPDATE, self.updateProgressDialog)
+        self.Bind(EVT_PROGRESS_END, self.destroyProgressDialog)
 
 
     ## Now that OpenGL's ready to go, perform any necessary initialization.


### PR DESCRIPTION
While fixing issue #793, I accidentally deleted the binding of the events while I was undoing the autoformatting (see #794). This should bring the progress bar back.

Fixes #804 