### PR TITLE
fix touchscreen power wavelength check

### DIFF
--- a/cockpit/gui/touchscreen.py
+++ b/cockpit/gui/touchscreen.py
@@ -579,9 +579,9 @@ class LightsPanelEntry(wx.Panel):
                 cockpit.gui.IMAGES_PATH, "touchscreen/misc_wavelength.png",
             )
         )
-        if self.power.wavelength == None:
-            self.power.wavelength = -50
         if self.power:
+            if self.power.wavelength is None:
+                self.power.wavelength = -50
             img.Replace(
                 255, 255, 255, *wavelengthToColor(self.power.wavelength)
             )


### PR DESCRIPTION
@iandobbie I'm updating the B24 cryoSIM and I found that your last commit caused me an error when starting Cockpit for the first time, since `power_handler` is None. This just moves your check and uses `is` rather than `==`.

Fixes #814 